### PR TITLE
Jcn quick add event listener timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `timeout` support for Event Listeners hooks
 
 ## [2.10.1] - 2020-04-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Used to implement JANIS Events listeners
 | listenersDirName | string | Indicates the path where the event listener files are placed | | `'event-listeners'` |
 | authorizer | string | The name of the authorizer | | If not set, it defaults to `ServiceAuthorizer` or `ServiceNoClientAuthorizer` based on the value of `mustHaveClient` |
 | package.include | array[string] | The List of paths of files to include |
+| timeout | number | The function timeout in seconds | | |
 
 ## Examples
 

--- a/lib/event-listener/index.js
+++ b/lib/event-listener/index.js
@@ -14,7 +14,8 @@ const eventListener = ({
 	mustHaveClient,
 	listenersDirName,
 	package: pkg,
-	authorizer
+	authorizer,
+	timeout
 }) => {
 
 	const serviceNameAsTitle = startcase(serviceName);
@@ -53,6 +54,9 @@ const eventListener = ({
 
 	if(pkg && pkg.include)
 		functionConfiguration.package = pkg;
+
+	if(timeout)
+		functionConfiguration.timeout = timeout;
 
 	return {
 		[`EL-${listenerCode}`]: functionConfiguration

--- a/tests/unit/hooks/event-listener.js
+++ b/tests/unit/hooks/event-listener.js
@@ -228,6 +228,45 @@ describe('Hooks', () => {
 					]
 				});
 			});
+
+			it('Should add the timeout if timeout param is passed', () => {
+
+				const serviceConfig = eventListener({}, {
+					serviceName: 'my service',
+					entityName: 'product name',
+					eventName: 'something happened',
+					mustHaveClient: true,
+					timeout: 20
+				});
+
+				assert.deepStrictEqual(serviceConfig, {
+					functions: [
+						{
+							'EL-MyServiceProductNameSomethingHappened': {
+								name: 'EL-${self:custom.serviceName}-MyServiceProductNameSomethingHappened-${self:custom.stage}',
+								handler: 'src/event-listeners/my-service/product-name/something-happened.handler',
+								description: 'My Service Product Name Something Happened Listener',
+								timeout: 20,
+								events: [
+									{
+										http: {
+											integration: 'lambda',
+											path: '/listener/my-service/product-name/something-happened',
+											method: 'post',
+											authorizer: '${self:custom.authorizers.ServiceAuthorizer}',
+											request: {
+												template: '${self:custom.apiRequestTemplate}'
+											},
+											response: '${self:custom.apiResponseTemplate}',
+											responses: '${self:custom.apiOfflineResponseTemplate}'
+										}
+									}
+								]
+							}
+						}
+					]
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
**LINK AL TICKET**
-
​
**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere agregar la propiedad `timeout` a los hooks de Event-Listeners
​
**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agregó la propiedad `timeout` a los hooks de Event-Listeners