### PR TITLE
Re-use authorizer lambda functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `AdminNoClientAuthorizer` now uses `AdminAuthorizer` lambda function
+- `NoClientAuthorizer` now uses `FullAuthorizer` lambda function
+
 ## [5.2.0] - 2021-06-18
 ### Added
 - New authorizers `AdminAuthorizer` and `AdminNoClientAuthorizer`

--- a/lib/service/authorizers.js
+++ b/lib/service/authorizers.js
@@ -5,7 +5,9 @@ const { inspect } = require('util');
 const defaultAuthorizers = require('./default-authorizers');
 
 const authorizersNameToFunctionMapping = {
-	ServiceNoClientAuthorizer: 'ServiceAuthorizer'
+	ServiceNoClientAuthorizer: 'ServiceAuthorizer',
+	AdminNoClientAuthorizer: 'AdminAuthorizer',
+	NoClientAuthorizer: 'FullAuthorizer'
 };
 
 const authorizerBuilder = (name, headers, accountId) => ({

--- a/tests/unit/hooks/authorizers.js
+++ b/tests/unit/hooks/authorizers.js
@@ -27,7 +27,7 @@ describe('Hooks', () => {
 
 			NoClientAuthorizer: {
 				name: 'NoClientAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-NoClientAuthorizer`,
+				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-FullAuthorizer`,
 				resultTtlInSeconds: 300,
 				identitySource: `${headerApiKey},${headerApiSecret}`,
 				type: 'request'
@@ -75,7 +75,7 @@ describe('Hooks', () => {
 
 			AdminNoClientAuthorizer: {
 				name: 'AdminNoClientAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-AdminNoClientAuthorizer`,
+				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-AdminAuthorizer`,
 				resultTtlInSeconds: 300,
 				identitySource: `${headerApiKey},${headerApiSecret}`,
 				type: 'request'


### PR DESCRIPTION
Ahora se re-utilizan los 2 authorizers.
- `AdminNoClientAuthorizer` usa la función `AdminAuthorizer`
- `NoClientAuthorizer` usa la función `FullAuthorizer`