### PR TITLE
Changed APIs function names standard

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -10,8 +10,9 @@
   "cache": true,
   "all": true,
   "check-coverage": true,
-  "lines": 90,
-  "statements": 90,
-  "functions": 90,
-  "branches": 90
+  "skip-full": true,
+  "lines": 100,
+  "statements": 100,
+  "functions": 100,
+  "branches": 100
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- APIs hooks can received `functionName` to use as function name
+
+### Changed
+- Standard for API CRUD function names
+
 ## [5.9.0] - 2022-11-16
 ### Added
 - Added support for the `skipTraceLayer` in APIs and set it as default in read APIs

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Used to implement a custom API
 
 | Option | Type | Description | Attributes | Default value |
 |--------|------|-------------|------------|---------------|
+| functionName | string | The name of the lambda function. Will be used in `API-{serviceName}-{functionName}-{stage}`. Since _5.6.0_ | | |
 | path | string | The API path | **Required** | |
 | method | string | The API HTTP Method | | `'get'` |
 | methodName | string | The JANIS API Method | Enum\<list, get, post, put, patch, delete\> | Defaults to same value of `method` option |
@@ -117,6 +118,7 @@ Used to implement JANIS CRUD APIs.
 
 | Option | Type | Description | Attributes | Default value |
 |--------|------|-------------|------------|---------------|
+| functionName | string | The name of the lambda function. Will be used in `API-{serviceName}-{functionName}-{stage}`. Since _5.6.0_ | | |
 | entityName | string | The entity name | **Required** | |
 | handler | string | The lambda handler path and function | | `'src/lambda/RestApi/index.handler'` |
 | path | string | The API path | | `/[entity-name]` (for apiList and apiPost) or `/[entity-name]/{id}` (for apiGet and apiPut) |

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -32,6 +32,7 @@ const apiPathToName = apiPath => apiPath
 const getFunctionName = (method, apiPath) => `${startcase(method)}${apiPathToName(apiPath)}`;
 
 const apiBase = ({
+	functionName,
 	path,
 	handler,
 	description,
@@ -80,7 +81,9 @@ const apiBase = ({
 	if(authorizer)
 		event.authorizer = `\${self:custom.authorizers.${authorizer}}`;
 
-	const functionName = getFunctionName(methodName, normalizedPath);
+	console.log(`this ${functionName}`);
+
+	functionName = functionName || getFunctionName(methodName, normalizedPath);
 
 	const functionConfiguration = {
 		name: `API-\${self:custom.serviceName}-${functionName}-\${self:custom.stage}`,

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -81,8 +81,6 @@ const apiBase = ({
 	if(authorizer)
 		event.authorizer = `\${self:custom.authorizers.${authorizer}}`;
 
-	console.log(`this ${functionName}`);
-
 	functionName = functionName || getFunctionName(methodName, normalizedPath);
 
 	const functionConfiguration = {

--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -83,8 +83,10 @@ const apiBase = ({
 	if(shouldAddTraceLayer() && skipTraceLayer)
 		optionalProperties.layers = removeTraceLayer(serviceConfig?.provider?.layers);
 
+	functionName = functionName || `${getFunctionNamePrefix(methodName)}-${entityNameAsTitle.replace(/ /g, '')}`
+
 	const functionConfiguration = {
-		name: `API${getFunctionNamePrefix(methodName)}-\${self:custom.serviceName}-${entityNameAsTitle.replace(/ /g, '')}-\${self:custom.stage}`,
+		name: `API-\${self:custom.serviceName}-${functionName}-\${self:custom.stage}`,
 		handler: handler || 'src/lambda/RestApi/index.handler',
 		description: `${entityNameAsTitle} ${startcase(methodName)} API`,
 		package: {
@@ -110,7 +112,7 @@ const apiBase = ({
 		functionConfiguration.timeout = timeout;
 
 	return {
-		[`API${getFunctionNamePrefix(methodName)}-${entityNameAsTitle.replace(/ /g, '')}`]: functionConfiguration
+		[`API-${functionName}`]: functionConfiguration
 	};
 };
 

--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -26,6 +26,7 @@ const getFunctionNamePrefix = methodName => {
 };
 
 const apiBase = ({
+	functionName,
 	entityName,
 	handler,
 	path,
@@ -83,7 +84,7 @@ const apiBase = ({
 	if(shouldAddTraceLayer() && skipTraceLayer)
 		optionalProperties.layers = removeTraceLayer(serviceConfig?.provider?.layers);
 
-	functionName = functionName || `${getFunctionNamePrefix(methodName)}-${entityNameAsTitle.replace(/ /g, '')}`
+	functionName = functionName || `${getFunctionNamePrefix(methodName)}-${entityNameAsTitle.replace(/ /g, '')}`;
 
 	const functionConfiguration = {
 		name: `API-\${self:custom.serviceName}-${functionName}-\${self:custom.stage}`,

--- a/tests/unit/hooks/api-base.js
+++ b/tests/unit/hooks/api-base.js
@@ -22,7 +22,7 @@ describe('Internal Hooks', () => {
 			it('Should throw if method param is passed as empty', () => {
 
 				assert.throws(() => apiBase.buildApi({}, {
-					entityName: 'product-name',
+					entityName: 'product-attribute',
 					method: ''
 				}), {
 					message: /method/
@@ -34,27 +34,27 @@ describe('Internal Hooks', () => {
 			it('Should return the service config with a default API config when passing the required params', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name'
+					entityName: 'product attribute'
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -76,21 +76,21 @@ describe('Internal Hooks', () => {
 			it('Should use a custom path if path param is passed', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					path: '/custom/path'
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
@@ -116,28 +116,28 @@ describe('Internal Hooks', () => {
 			it('Should add the id variable if pathHasId param is passed', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					pathHasId: true
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name/{id}',
+											path: '/product-attribute/{id}',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}',
@@ -164,12 +164,12 @@ describe('Internal Hooks', () => {
 			it('Should throw if passed request templates are not an object', () => {
 
 				assert.throws(() => apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					requestTemplates: 'not an object'
 				}));
 
 				assert.throws(() => apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					requestTemplates: [{
 						'application/x-www-form-urlencoded': null,
 						'application/json': 'custom template',
@@ -182,7 +182,7 @@ describe('Internal Hooks', () => {
 			it('Should override and add the passed request templates', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					requestTemplates: {
 						'application/x-www-form-urlencoded': null,
 						'application/json': 'custom template',
@@ -193,21 +193,21 @@ describe('Internal Hooks', () => {
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: {
@@ -230,21 +230,21 @@ describe('Internal Hooks', () => {
 			it('Should parse path parameters and add them to request parameters object', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					path: '/custom/{id}/path/{secondId}'
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
@@ -276,7 +276,7 @@ describe('Internal Hooks', () => {
 			it('Should parse path parameters and add them to request parameters object', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					queryParameters: {
 						requiredQuery: true,
 						optionalQuery: false
@@ -290,21 +290,21 @@ describe('Internal Hooks', () => {
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}',
@@ -344,28 +344,28 @@ describe('Internal Hooks', () => {
 			it('Should use the methodName param to override method for files and naming', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					methodName: 'custom'
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APICustom-ProductName': {
-								name: 'APICustom-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Custom-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Custom-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Custom API',
+								description: 'Product Attribute Custom API',
 								package: {
 									include: [
-										'src/api/product-name/custom.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/custom.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -384,28 +384,28 @@ describe('Internal Hooks', () => {
 			it('Should use the handler param to override the default', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					handler: 'path/to/custom.handler'
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'path/to/custom.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -424,28 +424,28 @@ describe('Internal Hooks', () => {
 			it('Should enable api cache if caching param is passed', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					caching: true
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											caching: {
 												enabled: '${self:custom.apiGatewayCaching.enabled}'
@@ -467,28 +467,28 @@ describe('Internal Hooks', () => {
 			it('Should enable default cors if cors param is passed as true', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					cors: true
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											cors: '${self:custom.cors}',
 											request: {
@@ -508,7 +508,7 @@ describe('Internal Hooks', () => {
 			it('Should enable customized cors if cors param is passed as an object', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					cors: {
 						replace: true,
 						origins: ['*'],
@@ -519,21 +519,21 @@ describe('Internal Hooks', () => {
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											cors: {
 												origins: ['*'],
@@ -570,7 +570,7 @@ describe('Internal Hooks', () => {
 			it('Should set an authorizer if authorizer param is passed', () => {
 
 				const serviceConfig = apiBase.buildApi(previousServiceConfig, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					authorizer: 'FullAuthorizer'
 				});
 
@@ -578,21 +578,21 @@ describe('Internal Hooks', () => {
 					...previousServiceConfig,
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											authorizer: '${self:custom.authorizers.FullAuthorizer}',
 											request: {
@@ -611,7 +611,7 @@ describe('Internal Hooks', () => {
 
 			it('Should throw an error in an invalid authorizer is passed', () => {
 				assert.throws(() => apiBase.buildApi(previousServiceConfig, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					authorizer: 'InvalidAuthorizer'
 				}));
 			});
@@ -619,21 +619,21 @@ describe('Internal Hooks', () => {
 			it('Should set the timeout if timeout param is passed', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					timeout: 10
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								timeout: 10,
@@ -641,7 +641,7 @@ describe('Internal Hooks', () => {
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -660,21 +660,21 @@ describe('Internal Hooks', () => {
 			it('Should append the package includes if package.include param is passed', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					package: { include: ['src/controllers/product.js'] }
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js',
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js',
 										'src/controllers/product.js'
 									]
 								},
@@ -682,7 +682,7 @@ describe('Internal Hooks', () => {
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -701,7 +701,7 @@ describe('Internal Hooks', () => {
 			it('Should set raw props in the function end event configuration if they are passed', () => {
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					functionRawProps: {
 						foo: 'bar',
 						description: 'Override it'
@@ -714,14 +714,14 @@ describe('Internal Hooks', () => {
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
 								description: 'Override it',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								foo: 'bar',
@@ -729,7 +729,7 @@ describe('Internal Hooks', () => {
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -763,7 +763,7 @@ describe('Internal Hooks', () => {
 						]
 					}
 				}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					skipTraceLayer: true
 				});
 
@@ -776,24 +776,24 @@ describe('Internal Hooks', () => {
 					},
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
 								layers: [
 									'arn:aws:lambda:us-east-1:123456789123:layer:other-layer:1'
 								],
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -825,7 +825,7 @@ describe('Internal Hooks', () => {
 						]
 					}
 				}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					skipTraceLayer: true
 				});
 
@@ -837,22 +837,22 @@ describe('Internal Hooks', () => {
 					},
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
 								layers: [],
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'
@@ -878,29 +878,29 @@ describe('Internal Hooks', () => {
 					});
 
 				const serviceConfig = apiBase.buildApi({}, {
-					entityName: 'product name',
+					entityName: 'product attribute',
 					skipTraceLayer: true
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
 					functions: [
 						{
-							'APIGet-ProductName': {
-								name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+							'API-Get-ProductAttribute': {
+								name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 								handler: 'src/lambda/RestApi/index.handler',
 								layers: [],
-								description: 'Product Name Get API',
+								description: 'Product Attribute Get API',
 								package: {
 									include: [
-										'src/api/product-name/get.js',
-										'src/models/product-name.js'
+										'src/api/product-attribute/get.js',
+										'src/models/product-attribute.js'
 									]
 								},
 								events: [
 									{
 										http: {
 											integration: 'lambda',
-											path: '/product-name',
+											path: '/product-attribute',
 											method: 'get',
 											request: {
 												template: '${self:custom.apiRequestTemplate}'

--- a/tests/unit/hooks/api-get.js
+++ b/tests/unit/hooks/api-get.js
@@ -44,27 +44,27 @@ describe('Hooks', () => {
 				};
 
 				const result = apiGet({ ...initialConfig }, {
-					entityName: 'product name'
+					entityName: 'product attribute'
 				});
 
 				assert.deepStrictEqual(result, {
 					provider: {},
 					functions: [{
-						'APIGet-ProductName': {
-							name: 'APIGet-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+						'API-Get-ProductAttribute': {
+							name: 'API-${self:custom.serviceName}-Get-ProductAttribute-${self:custom.stage}',
 							handler: 'src/lambda/RestApi/index.handler',
-							description: 'Product Name Get API',
+							description: 'Product Attribute Get API',
 							package: {
 								include: [
-									'src/api/product-name/get.js',
-									'src/models/product-name.js'
+									'src/api/product-attribute/get.js',
+									'src/models/product-attribute.js'
 								]
 							},
 							events: [
 								{
 									http: {
 										integration: 'lambda',
-										path: '/product-name/{id}',
+										path: '/product-attribute/{id}',
 										method: 'get',
 										request: {
 											template: '${self:custom.apiRequestTemplate}',

--- a/tests/unit/hooks/api-list.js
+++ b/tests/unit/hooks/api-list.js
@@ -46,27 +46,27 @@ describe('Hooks', () => {
 				};
 
 				const result = apiList({ ...initialConfig }, {
-					entityName: 'product name'
+					entityName: 'product attribute'
 				});
 
 				assert.deepStrictEqual(result, {
 					provider: {},
 					functions: [{
-						'APIList-ProductName': {
-							name: 'APIList-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+						'API-List-ProductAttribute': {
+							name: 'API-${self:custom.serviceName}-List-ProductAttribute-${self:custom.stage}',
 							handler: 'src/lambda/RestApi/index.handler',
-							description: 'Product Name List API',
+							description: 'Product Attribute List API',
 							package: {
 								include: [
-									'src/api/product-name/list.js',
-									'src/models/product-name.js'
+									'src/api/product-attribute/list.js',
+									'src/models/product-attribute.js'
 								]
 							},
 							events: [
 								{
 									http: {
 										integration: 'lambda',
-										path: '/product-name',
+										path: '/product-attribute',
 										method: 'get',
 										request: {
 											template: '${self:custom.apiRequestTemplate}'

--- a/tests/unit/hooks/api-post.js
+++ b/tests/unit/hooks/api-post.js
@@ -44,27 +44,27 @@ describe('Hooks', () => {
 				};
 
 				const result = apiPost({ ...initialConfig }, {
-					entityName: 'product name'
+					entityName: 'product attribute'
 				});
 
 				assert.deepStrictEqual(result, {
 					provider: {},
 					functions: [{
-						'APICreate-ProductName': {
-							name: 'APICreate-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+						'API-Create-ProductAttribute': {
+							name: 'API-${self:custom.serviceName}-Create-ProductAttribute-${self:custom.stage}',
 							handler: 'src/lambda/RestApi/index.handler',
-							description: 'Product Name Post API',
+							description: 'Product Attribute Post API',
 							package: {
 								include: [
-									'src/api/product-name/post.js',
-									'src/models/product-name.js'
+									'src/api/product-attribute/post.js',
+									'src/models/product-attribute.js'
 								]
 							},
 							events: [
 								{
 									http: {
 										integration: 'lambda',
-										path: '/product-name',
+										path: '/product-attribute',
 										method: 'post',
 										request: {
 											template: '${self:custom.apiRequestTemplate}'

--- a/tests/unit/hooks/api-put.js
+++ b/tests/unit/hooks/api-put.js
@@ -43,27 +43,75 @@ describe('Hooks', () => {
 				};
 
 				const result = apiPut({ ...initialConfig }, {
-					entityName: 'product name'
+					entityName: 'product attribute'
 				});
 
 				assert.deepStrictEqual(result, {
 					provider: {},
 					functions: [{
-						'APIUpdate-ProductName': {
-							name: 'APIUpdate-${self:custom.serviceName}-ProductName-${self:custom.stage}',
+						'API-Update-ProductAttribute': {
+							name: 'API-${self:custom.serviceName}-Update-ProductAttribute-${self:custom.stage}',
 							handler: 'src/lambda/RestApi/index.handler',
-							description: 'Product Name Put API',
+							description: 'Product Attribute Put API',
 							package: {
 								include: [
-									'src/api/product-name/put.js',
-									'src/models/product-name.js'
+									'src/api/product-attribute/put.js',
+									'src/models/product-attribute.js'
 								]
 							},
 							events: [
 								{
 									http: {
 										integration: 'lambda',
-										path: '/product-name/{id}',
+										path: '/product-attribute/{id}',
+										method: 'put',
+										request: {
+											template: '${self:custom.apiRequestTemplate}',
+											parameters: {
+												paths: {
+													id: true
+												}
+											}
+										},
+										response: '${self:custom.apiResponseTemplate}',
+										responses: '${self:custom.apiOfflineResponseTemplate}'
+									}
+								}
+							]
+						}
+					}]
+				});
+			});
+
+			it('Should set a custom function name when functionName was received', () => {
+
+				const initialConfig = {
+					provider: {}
+				};
+
+				const result = apiPut({ ...initialConfig }, {
+					entityName: 'product attribute',
+					functionName: 'UpdateProductAttribute'
+				});
+
+				assert.deepStrictEqual(result, {
+					provider: {},
+					functions: [{
+						'API-UpdateProductAttribute': {
+							name: 'API-${self:custom.serviceName}-UpdateProductAttribute-${self:custom.stage}',
+							handler: 'src/lambda/RestApi/index.handler',
+							description: 'Product Attribute Put API',
+							package: {
+								include: [
+									'src/api/product-attribute/put.js',
+									'src/models/product-attribute.js'
+								]
+							},
+							events: [
+								{
+									http: {
+										integration: 'lambda',
+										path: '/product-attribute/{id}',
 										method: 'put',
 										request: {
 											template: '${self:custom.apiRequestTemplate}',

--- a/tests/unit/hooks/api.js
+++ b/tests/unit/hooks/api.js
@@ -29,6 +29,20 @@ describe('Hooks', () => {
 		});
 
 		context('Default configuration', () => {
+
+			const defaultHttpEvent = {
+				http: {
+					integration: 'lambda',
+					path: '/hello-world',
+					method: 'get',
+					request: {
+						template: '${self:custom.apiRequestTemplate}'
+					},
+					response: '${self:custom.apiResponseTemplate}',
+					responses: '${self:custom.apiOfflineResponseTemplate}'
+				}
+			};
+
 			it('Should return the service config with a default API config when passing the required params', () => {
 
 				const serviceConfig = api({}, {
@@ -47,20 +61,33 @@ describe('Hooks', () => {
 										'src/api/hello-world/get.js'
 									]
 								},
-								events: [
-									{
-										http: {
-											integration: 'lambda',
-											path: '/hello-world',
-											method: 'get',
-											request: {
-												template: '${self:custom.apiRequestTemplate}'
-											},
-											response: '${self:custom.apiResponseTemplate}',
-											responses: '${self:custom.apiOfflineResponseTemplate}'
-										}
-									}
-								]
+								events: [defaultHttpEvent]
+							}
+						}
+					]
+				});
+			});
+
+			it('Should return the service config and API config with custom function name when functionName parameter received', () => {
+
+				const serviceConfig = api({}, {
+					path: '/hello-world',
+					functionName: 'HelloWorld'
+				});
+
+				assert.deepStrictEqual(serviceConfig, {
+					functions: [
+						{
+							'API-HelloWorld': {
+								name: 'API-${self:custom.serviceName}-HelloWorld-${self:custom.stage}',
+								handler: 'src/lambda/RestApi/index.handler',
+								description: undefined,
+								package: {
+									include: [
+										'src/api/hello-world/get.js'
+									]
+								},
+								events: [defaultHttpEvent]
 							}
 						}
 					]
@@ -85,20 +112,7 @@ describe('Hooks', () => {
 										'src/api/hello-world/get.js'
 									]
 								},
-								events: [
-									{
-										http: {
-											integration: 'lambda',
-											path: '/hello-world',
-											method: 'get',
-											request: {
-												template: '${self:custom.apiRequestTemplate}'
-											},
-											response: '${self:custom.apiResponseTemplate}',
-											responses: '${self:custom.apiOfflineResponseTemplate}'
-										}
-									}
-								]
+								events: [defaultHttpEvent]
 							}
 						}
 					]


### PR DESCRIPTION
## CHANGELOG

### Added
- APIs hooks can received `functionName` to use as function name

### Changed
- Standard for API CRUD function names