### PR TITLE
state-machine parameters

### DIFF
--- a/lib/state-machine/index.js
+++ b/lib/state-machine/index.js
@@ -5,27 +5,41 @@ const camelCase = require('lodash.camelcase');
 
 const pascalCase = name => startCase(camelCase(name)).replace(/ /g, '');
 
+const addParametersToTask = task => {
+
+	if(task.Parameters?.Payload)
+		task.Parameters.Payload['stateMachine.$'] = '$$.StateMachine';
+	else if(task.Parameters)
+		task.Parameters['stateMachine.$'] = '$$.StateMachine';
+	else {
+		task.Parameters = {
+			'session.$': '$.session',
+			'body.$': '$.body',
+			'stateMachine.$': '$$.StateMachine'
+		};
+	}
+};
+
+const addParametersToSates = states => {
+
+	Object.values(states).forEach(step => {
+
+		if(step.Type === 'Map')
+			return addParametersToSates(step.ItemProcessor.States);
+
+		if(step.Type === 'Parallel')
+			return step.Branches.forEach(branch => addParametersToSates(branch.States));
+
+		if(step.Type === 'Task')
+			addParametersToTask(step);
+	});
+};
+
 const addStateMachineParameter = definition => {
 
 	const definitionParsed = JSON.parse(JSON.stringify(definition));
 
-	Object.values(definitionParsed.States).forEach(step => {
-
-		if(step.Type !== 'Task')
-			return;
-
-		if(step.Parameters?.Payload)
-			step.Parameters.Payload['stateMachine.$'] = '$$.StateMachine';
-		else if(step.Parameters)
-			step.Parameters['stateMachine.$'] = '$$.StateMachine';
-		else {
-			step.Parameters = {
-				'session.$': '$.session',
-				'body.$': '$.body',
-				'stateMachine.$': '$$.StateMachine'
-			};
-		}
-	});
+	addParametersToSates(definitionParsed.States);
 
 	return definitionParsed;
 };

--- a/lib/state-machine/index.js
+++ b/lib/state-machine/index.js
@@ -5,6 +5,31 @@ const camelCase = require('lodash.camelcase');
 
 const pascalCase = name => startCase(camelCase(name)).replace(/ /g, '');
 
+const addStateMachineParameter = definition => {
+
+	const definitionParsed = JSON.parse(JSON.stringify(definition));
+
+	Object.values(definitionParsed.States).forEach(step => {
+
+		if(step.Type !== 'Task')
+			return;
+
+		if(step.Parameters?.Payload)
+			step.Parameters.Payload['stateMachine.$'] = '$$.StateMachine';
+		else if(step.Parameters)
+			step.Parameters['stateMachine.$'] = '$$.StateMachine';
+		else {
+			step.Parameters = {
+				'session.$': '$.session',
+				'body.$': '$.body',
+				'stateMachine.$': '$$.StateMachine'
+			};
+		}
+	});
+
+	return definitionParsed;
+};
+
 const stateMachineFunction = ({
 	name: stepMachineName,
 	definition
@@ -14,7 +39,7 @@ const stateMachineFunction = ({
 
 	const stepMachineConfiguration = {
 		name: `\${self:custom.serviceName}-${stepMachineNameInCamelCase}-\${self:custom.stage}`,
-		definition
+		definition: addStateMachineParameter(definition)
 	};
 
 	const stepMachineNameInPascalCase = pascalCase(stepMachineName);

--- a/tests/unit/hooks/state-machine.js
+++ b/tests/unit/hooks/state-machine.js
@@ -28,29 +28,6 @@ describe('Hooks', () => {
 		}
 	};
 
-	const stateTrackingCall = {
-		Type: 'Task',
-		Resources: 'arn:aws:states:::lambda',
-		Next: 'EndCall'
-	};
-
-	const hookWithTaskGenerator = parameters => {
-
-		return {
-			name: 'MachineName',
-			definition: {
-				...definition,
-				States: {
-					...definition.States,
-					TrackingCall: {
-						...stateTrackingCall,
-						...parameters && { Parameters: parameters }
-					}
-				}
-			}
-		};
-	};
-
 	describe('State Machine', () => {
 
 		context('Config validation', () => {
@@ -78,13 +55,10 @@ describe('Hooks', () => {
 
 			it('Should return the service config with the plugin, stepFunctions and the machines when passing the required params', () => {
 
-				const hooksParams = hookWithTaskGenerator();
-
-				const hookParamsParsed = hookWithTaskGenerator({
-					'session.$': '$.session',
-					'body.$': '$.body',
-					'stateMachine.$': '$$.StateMachine'
-				});
+				const hooksParams = {
+					name: 'MachineName',
+					definition
+				};
 
 				const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
 
@@ -97,7 +71,7 @@ describe('Hooks', () => {
 					stepFunctions: {
 						stateMachines: {
 							MachineName: {
-								...hookParamsParsed,
+								...hooksParams,
 								name: machineName
 							}
 						}
@@ -126,20 +100,10 @@ describe('Hooks', () => {
 
 			it('Should return the service config and the state machine with name in camelCase', () => {
 
-				const hooksParams = hookWithTaskGenerator({
-					Payload: {
-						'session.$': '$.session',
-						'body.$': '$.body'
-					}
-				});
-
-				const hookParamsParsed = hookWithTaskGenerator({
-					Payload: {
-						'session.$': '$.session',
-						'body.$': '$.body',
-						'stateMachine.$': '$$.StateMachine'
-					}
-				});
+				const hooksParams = {
+					name: 'Machine Name',
+					definition
+				};
 
 				const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
 
@@ -152,7 +116,7 @@ describe('Hooks', () => {
 					stepFunctions: {
 						stateMachines: {
 							MachineName: {
-								...hookParamsParsed,
+								...hooksParams,
 								name: machineName
 							}
 						}
@@ -181,16 +145,10 @@ describe('Hooks', () => {
 
 			it('Should return the service config with plugins, stepFunctions and the machines when passing the required params', () => {
 
-				const hooksParams = hookWithTaskGenerator({
-					'session.$': '$.session',
-					'body.$': '$.body'
-				});
-
-				const hookParamsParsed = hookWithTaskGenerator({
-					'session.$': '$.session',
-					'body.$': '$.body',
-					'stateMachine.$': '$$.StateMachine'
-				});
+				const hooksParams = {
+					name: 'MachineName',
+					definition
+				};
 
 				const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
 
@@ -203,7 +161,7 @@ describe('Hooks', () => {
 					stepFunctions: {
 						stateMachines: {
 							[pascalCase(hooksParams.name)]: {
-								...hookParamsParsed,
+								...hooksParams,
 								name: machineName
 							}
 						}
@@ -397,6 +355,565 @@ describe('Hooks', () => {
 							}
 						}
 					}
+				});
+			});
+		});
+
+		context('State Machine generation with fixed parameters in tasks', () => {
+
+			context('When the task is in the root of the state machine', () => {
+
+				const definitionWithTask = parameters => ({
+					Comment: 'Create Session Machine',
+					StartAt: 'ProcessCall',
+					States: {
+						ProcessCall: {
+							Type: 'Task',
+							...parameters && { Parameters: parameters },
+							Next: 'TrackingCall'
+						}
+					}
+				});
+
+				it('Should return the service config with the complete parameters when does not exist in the task', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: definitionWithTask()
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: definitionWithTask({
+							'session.$': '$.session',
+							'body.$': '$.body',
+							'stateMachine.$': '$$.StateMachine'
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
+				});
+
+				it('Should return the service config with the the new param (stateMachine) when the parameters exist in the task', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: definitionWithTask({
+							'session.$': '$.session',
+							'body.$': '$.body'
+						})
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: definitionWithTask({
+							'session.$': '$.session',
+							'body.$': '$.body',
+							'stateMachine.$': '$$.StateMachine'
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
+				});
+
+				it('Should return the service config with the the new param (stateMachine) when the parameters has a "Payload" in the task', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: definitionWithTask({
+							Payload: {
+								'session.$': '$.session',
+								'body.$': '$.body'
+							}
+						})
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: definitionWithTask({
+							Payload: {
+								'session.$': '$.session',
+								'body.$': '$.body',
+								'stateMachine.$': '$$.StateMachine'
+							}
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
+				});
+			});
+
+			context('When tasks are in other states', () => {
+
+				const generateDefinitionByState = state => ({
+					Comment: 'Create Session Machine',
+					StartAt: 'ProcessCall',
+					States: {
+						...state
+					}
+				});
+
+				it('Should return the service config with the complete parameters when the task is in a Map type state', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Map',
+								ItemProcessor: {
+									ProcessorConfig: {
+										Mode: 'DISTRIBUTED',
+										ExecutionType: 'EXPRESS'
+									},
+									StartAt: 'TrackingCall',
+									States: {
+										TrackingCall: {
+											Type: 'Task',
+											End: true
+										}
+									}
+								},
+								Next: 'TrackingCall'
+							}
+						})
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Map',
+								ItemProcessor: {
+									ProcessorConfig: {
+										Mode: 'DISTRIBUTED',
+										ExecutionType: 'EXPRESS'
+									},
+									StartAt: 'TrackingCall',
+									States: {
+										TrackingCall: {
+											Type: 'Task',
+											Parameters: {
+												'session.$': '$.session',
+												'body.$': '$.body',
+												'stateMachine.$': '$$.StateMachine'
+											},
+											End: true
+										}
+									}
+								},
+								Next: 'TrackingCall'
+							}
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
+				});
+
+				it('Should return the service config with the complete parameters when the task is in a Parallel type state', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Parallel',
+								Branches: [
+									{
+										StartAt: 'EndCall',
+										States: {
+											EndCall: {
+												Type: 'Task',
+												End: true
+											}
+										}
+									},
+									{
+										StartAt: 'NotifyCall',
+										States: {
+											NotifyCall: {
+												Type: 'Task',
+												End: true
+											}
+										}
+									}
+								]
+							}
+						})
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Parallel',
+								Branches: [
+									{
+										StartAt: 'EndCall',
+										States: {
+											EndCall: {
+												Type: 'Task',
+												Parameters: {
+													'session.$': '$.session',
+													'body.$': '$.body',
+													'stateMachine.$': '$$.StateMachine'
+												},
+												End: true
+											}
+										}
+									},
+									{
+										StartAt: 'NotifyCall',
+										States: {
+											NotifyCall: {
+												Type: 'Task',
+												Parameters: {
+													'session.$': '$.session',
+													'body.$': '$.body',
+													'stateMachine.$': '$$.StateMachine'
+												},
+												End: true
+											}
+										}
+									}
+								]
+							}
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
+				});
+
+				it('Should return the service config with the complete parameters when tasks exist at different levels.', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Task',
+								Next: 'TrackingCall'
+							},
+							TrackingCall: {
+								Type: 'Parallel',
+								Branches: [
+									{
+										StartAt: 'EndCall',
+										States: {
+											EndCall: {
+												Type: 'Map',
+												ItemProcessor: {
+													ProcessorConfig: {
+														Mode: 'DISTRIBUTED',
+														ExecutionType: 'EXPRESS'
+													},
+													StartAt: 'SendMessage',
+													States: {
+														SendMessage: {
+															Type: 'Task',
+															Parameters: {
+																'session.$': '$.session',
+																'body.$': '$.body'
+															},
+															End: true
+														}
+													}
+												},
+												End: true
+											}
+										}
+									},
+									{
+										StartAt: 'NotifyCall',
+										States: {
+											NotifyCall: {
+												Type: 'Task',
+												Parameters: {
+													Payload: {
+														'session.$': '$.session',
+														'body.$': '$.body'
+													}
+												},
+												End: true
+											}
+										}
+									}
+								]
+							}
+						})
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Task',
+								Parameters: {
+									'session.$': '$.session',
+									'body.$': '$.body',
+									'stateMachine.$': '$$.StateMachine'
+								},
+								Next: 'TrackingCall'
+							},
+							TrackingCall: {
+								Type: 'Parallel',
+								Branches: [
+									{
+										StartAt: 'EndCall',
+										States: {
+											EndCall: {
+												Type: 'Map',
+												ItemProcessor: {
+													ProcessorConfig: {
+														Mode: 'DISTRIBUTED',
+														ExecutionType: 'EXPRESS'
+													},
+													StartAt: 'SendMessage',
+													States: {
+														SendMessage: {
+															Type: 'Task',
+															Parameters: {
+																'session.$': '$.session',
+																'body.$': '$.body',
+																'stateMachine.$': '$$.StateMachine'
+															},
+															End: true
+														}
+													}
+												},
+												End: true
+											}
+										}
+									},
+									{
+										StartAt: 'NotifyCall',
+										States: {
+											NotifyCall: {
+												Type: 'Task',
+												Parameters: {
+													Payload: {
+														'session.$': '$.session',
+														'body.$': '$.body',
+														'stateMachine.$': '$$.StateMachine'
+													}
+												},
+												End: true
+											}
+										}
+									}
+								]
+							}
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
 				});
 			});
 		});

--- a/tests/unit/hooks/state-machine.js
+++ b/tests/unit/hooks/state-machine.js
@@ -28,6 +28,29 @@ describe('Hooks', () => {
 		}
 	};
 
+	const stateTrackingCall = {
+		Type: 'Task',
+		Resources: 'arn:aws:states:::lambda',
+		Next: 'EndCall'
+	};
+
+	const hookWithTaskGenerator = parameters => {
+
+		return {
+			name: 'MachineName',
+			definition: {
+				...definition,
+				States: {
+					...definition.States,
+					TrackingCall: {
+						...stateTrackingCall,
+						...parameters && { Parameters: parameters }
+					}
+				}
+			}
+		};
+	};
+
 	describe('State Machine', () => {
 
 		context('Config validation', () => {
@@ -55,10 +78,13 @@ describe('Hooks', () => {
 
 			it('Should return the service config with the plugin, stepFunctions and the machines when passing the required params', () => {
 
-				const hooksParams = {
-					name: 'MachineName',
-					definition
-				};
+				const hooksParams = hookWithTaskGenerator();
+
+				const hookParamsParsed = hookWithTaskGenerator({
+					'session.$': '$.session',
+					'body.$': '$.body',
+					'stateMachine.$': '$$.StateMachine'
+				});
 
 				const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
 
@@ -71,7 +97,7 @@ describe('Hooks', () => {
 					stepFunctions: {
 						stateMachines: {
 							MachineName: {
-								...hooksParams,
+								...hookParamsParsed,
 								name: machineName
 							}
 						}
@@ -100,10 +126,20 @@ describe('Hooks', () => {
 
 			it('Should return the service config and the state machine with name in camelCase', () => {
 
-				const hooksParams = {
-					name: 'Machine Name',
-					definition
-				};
+				const hooksParams = hookWithTaskGenerator({
+					Payload: {
+						'session.$': '$.session',
+						'body.$': '$.body'
+					}
+				});
+
+				const hookParamsParsed = hookWithTaskGenerator({
+					Payload: {
+						'session.$': '$.session',
+						'body.$': '$.body',
+						'stateMachine.$': '$$.StateMachine'
+					}
+				});
 
 				const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
 
@@ -116,7 +152,7 @@ describe('Hooks', () => {
 					stepFunctions: {
 						stateMachines: {
 							MachineName: {
-								...hooksParams,
+								...hookParamsParsed,
 								name: machineName
 							}
 						}
@@ -145,10 +181,16 @@ describe('Hooks', () => {
 
 			it('Should return the service config with plugins, stepFunctions and the machines when passing the required params', () => {
 
-				const hooksParams = {
-					name: 'MachineName',
-					definition
-				};
+				const hooksParams = hookWithTaskGenerator({
+					'session.$': '$.session',
+					'body.$': '$.body'
+				});
+
+				const hookParamsParsed = hookWithTaskGenerator({
+					'session.$': '$.session',
+					'body.$': '$.body',
+					'stateMachine.$': '$$.StateMachine'
+				});
 
 				const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
 
@@ -161,7 +203,7 @@ describe('Hooks', () => {
 					stepFunctions: {
 						stateMachines: {
 							[pascalCase(hooksParams.name)]: {
-								...hooksParams,
+								...hookParamsParsed,
 								name: machineName
 							}
 						}


### PR DESCRIPTION
Recomiendo leer el ticket [JCN-418](https://fizzmod.atlassian.net/browse/JCN-418) que tiene el contexto completo, pero lo que se ajusto es que a partir de ahora todas las state machine al momento de generar la configuración se le agrego el parámetro para que dentro del Payload viaje `stateMachine` con el contenido del [Context Object](https://docs.aws.amazon.com/step-functions/latest/dg/input-output-contextobject.html) sobre la state machine para poderla identificar.