### PR TITLE
Jcn 419 step function with fixed parameter

### DIFF
--- a/lib/state-machine/index.js
+++ b/lib/state-machine/index.js
@@ -27,7 +27,15 @@ const addParametersToTask = task => {
 
 const addParametersToSates = states => {
 
-	Object.values(states).forEach(step => {
+	const stepsToExclude = Object.values(states).reduce((accum, step) => {
+
+		if(step.Type === 'Parallel' && step.Next)
+			accum.push(step.Next);
+
+		return accum;
+	}, []);
+
+	Object.entries(states).forEach(([stepName, step]) => {
 
 		if(step.Type === 'Map')
 			return addParametersToSates(step.ItemProcessor?.States || step.Iterator?.States || {});
@@ -35,7 +43,7 @@ const addParametersToSates = states => {
 		if(step.Type === 'Parallel')
 			return step.Branches.forEach(branch => addParametersToSates(branch.States));
 
-		if(step.Type === 'Task')
+		if(step.Type === 'Task' && !stepsToExclude.includes(stepName))
 			addParametersToTask(step);
 	});
 };

--- a/tests/unit/hooks/state-machine.js
+++ b/tests/unit/hooks/state-machine.js
@@ -877,7 +877,7 @@ describe('Hooks', () => {
 					});
 				});
 
-				it('Should return the service config with the complete parameters when the task is in a Parallel type state', () => {
+				it('Should return the service configuration omitting the parameters when the task receives data from Parallel', () => {
 
 					const hooksParams = {
 						name: 'MachineName',
@@ -886,24 +886,20 @@ describe('Hooks', () => {
 								Type: 'Parallel',
 								Branches: [
 									{
-										StartAt: 'EndCall',
+										StartAt: 'StartCall',
 										States: {
-											EndCall: {
-												Type: 'Task',
-												End: true
-											}
-										}
-									},
-									{
-										StartAt: 'NotifyCall',
-										States: {
-											NotifyCall: {
+											StartCall: {
 												Type: 'Task',
 												End: true
 											}
 										}
 									}
-								]
+								],
+								Next: 'EndCall'
+							},
+							EndCall: {
+								Type: 'Task',
+								End: true
 							}
 						})
 					};
@@ -915,23 +911,9 @@ describe('Hooks', () => {
 								Type: 'Parallel',
 								Branches: [
 									{
-										StartAt: 'EndCall',
+										StartAt: 'StartCall',
 										States: {
-											EndCall: {
-												Type: 'Task',
-												Parameters: {
-													'session.$': '$.session',
-													'body.$': '$.body',
-													'stateMachine.$': '$$.StateMachine'
-												},
-												End: true
-											}
-										}
-									},
-									{
-										StartAt: 'NotifyCall',
-										States: {
-											NotifyCall: {
+											StartCall: {
 												Type: 'Task',
 												Parameters: {
 													'session.$': '$.session',
@@ -942,7 +924,12 @@ describe('Hooks', () => {
 											}
 										}
 									}
-								]
+								],
+								Next: 'EndCall'
+							},
+							EndCall: {
+								Type: 'Task',
+								End: true
 							}
 						})
 					};

--- a/tests/unit/hooks/state-machine.js
+++ b/tests/unit/hooks/state-machine.js
@@ -877,6 +877,114 @@ describe('Hooks', () => {
 					});
 				});
 
+				it('Should return the service config with the complete parameters when the task is in a Parallel type state', () => {
+
+					const hooksParams = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Parallel',
+								Branches: [
+									{
+										StartAt: 'EndCall',
+										States: {
+											EndCall: {
+												Type: 'Task',
+												End: true
+											}
+										}
+									},
+									{
+										StartAt: 'NotifyCall',
+										States: {
+											NotifyCall: {
+												Type: 'Task',
+												End: true
+											}
+										}
+									}
+								]
+							}
+						})
+					};
+
+					const hooksParamsResult = {
+						name: 'MachineName',
+						definition: generateDefinitionByState({
+							ProcessCall: {
+								Type: 'Parallel',
+								Branches: [
+									{
+										StartAt: 'EndCall',
+										States: {
+											EndCall: {
+												Type: 'Task',
+												Parameters: {
+													'session.$': '$.session',
+													'body.$': '$.body',
+													'stateMachine.$': '$$.StateMachine'
+												},
+												End: true
+											}
+										}
+									},
+									{
+										StartAt: 'NotifyCall',
+										States: {
+											NotifyCall: {
+												Type: 'Task',
+												Parameters: {
+													'session.$': '$.session',
+													'body.$': '$.body',
+													'stateMachine.$': '$$.StateMachine'
+												},
+												End: true
+											}
+										}
+									}
+								]
+							}
+						})
+					};
+
+					const machineName = '${self:custom.serviceName}-machineName-${self:custom.stage}';
+
+					const serviceConfig = stateMachine({}, hooksParams);
+
+					assert.deepStrictEqual(serviceConfig, {
+						plugins: [
+							'serverless-step-functions'
+						],
+						stepFunctions: {
+							stateMachines: {
+								MachineName: {
+									...hooksParamsResult,
+									name: machineName
+								}
+							}
+						},
+						custom: {
+							machines: {
+								MachineName: {
+									name: '${self:custom.serviceName}-machineName-${self:custom.stage}',
+									arn: {
+										'Fn::Join': [
+											':',
+											[
+												'arn:aws:states',
+												'${self:custom.region}',
+												{ Ref: 'AWS::AccountId' },
+												'stateMachine',
+												'${self:custom.machines.MachineName.name}'
+											]
+										]
+									}
+								}
+							}
+						}
+					});
+				});
+
 				it('Should return the service configuration omitting the parameters when the task receives data from Parallel', () => {
 
 					const hooksParams = {


### PR DESCRIPTION
Haciendo pruebas con Parallel y para evitar errores de estructura ya que puede recibir un array o un objeto según sea el caso, se omite agregar parametros en la task que recibe el output del Parallel, esto se va a compensar desde el package de lambda que va a complementar los casos de state machine