### PR TITLE
Added VPC Configuration with env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - VPC Config for all functions of the service using env vars
 
+### Changed
+- Now the `accountId` for hook `authorizers` is read from env var `AUTHORIZER_ACCOUNT_ID`
+
 ## [7.2.1] - 2023-05-29
 ### Fixed
 - Added `@babel/runtime` to default package includes to avoid breaking services that use `date-fns`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- VPC Config for all functions of the service using env vars
+
 ## [7.2.1] - 2023-05-29
 ### Fixed
 - Added `@babel/runtime` to default package includes to avoid breaking services that use `date-fns`
@@ -57,7 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rolled back to `serverless-plugin-split-stacks` plugin instead of `@janiscommerce/serverless-plugin-split-stacks` **BREAKING CHANGE**
 
 ### Deprecated
-- Serveless `${self:custom.janisDomains}` and `${self:custom.humanReadableStage}` variables deprecated in favor of `${param:janisDomain}` and `${param:humanReadableStage}`. Custom props will be removed in a future major version.
+- Serverless `${self:custom.janisDomains}` and `${self:custom.humanReadableStage}` variables deprecated in favor of `${param:janisDomain}` and `${param:humanReadableStage}`. Custom props will be removed in a future major version.
 
 ### Removed
 - 'janis.base` does not accept `apiSecrets` any more. AWS Secrets manager must be used instead. **BREAKING CHANGE**
@@ -81,11 +84,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [5.13.1] - 2023-01-02
 ### Fixed
-- Fixed mapping of Map states with differente iterator properties
+- Fixed mapping of Map states with different iterator properties
 
 ## [5.13.0] - 2022-12-26
 ### Added
-- Step function hook now sets Task `Parameters` to include `session`, `body` and `stepFunction` data, so Lmabdas con detect if they are being run inside a step function
+- Step function hook now sets Task `Parameters` to include `session`, `body` and `stepFunction` data, so Lambdas con detect if they are being run inside a step function
 
 ## [5.12.0] - 2022-12-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The following custom props will be set: `custom.machines.MySuperMachine.arn` and
 
 ### functionsVpc
 
-_(since 7.1.0)_
+_(since 8.0.0)_
 
 Used to attach the service to a VPC with a Custom Security Group
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ _No options_
 
 ### authorizers
 
-Used to implement APIs authorizers as custom props
+Used to implement APIs authorizers as custom props.
 
-| Option | Type | Description | Attributes | Default value |
-|--------|------|-------------|------------|---------------|
-| accountId | string | Indicates the AWS account ID where the authorizers are deployed | **Required** | |
+Using the env var `AUTHORIZER_ACCOUNT_ID` that indicates the AWS account ID where the authorizers are deployed. **Required**.
 
 ### cors
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The following custom props will be set: `custom.machines.MySuperMachine.arn` and
 
 ### functionsVpc
 
-_(since 8.0.0)_
+_(since 7.1.0)_
 
 Used to attach the service to a VPC with a Custom Security Group
 
@@ -219,7 +219,7 @@ It will automatically create a Security Group in the given VPC and attach it to 
 
 ### VPC Configuration
 
-_(since 7.3.0)_
+_(since 8.0.0)_
 
 If the env vars `LAMBDA_SECURITY_GROUP_ID` and `LAMBDA_SUBNET_IDS` are set, the global VPC configuration for **all functions** added in the service will be added in `provider`.
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,19 @@ It will automatically create a Security Group in the given VPC and attach it to 
 }]
 ```
 
+### VPC Configuration
+
+_(since 7.3.0)_
+
+If the env vars `LAMBDA_SECURITY_GROUP_ID` and `LAMBDA_SUBNET_IDS` are set, the global VPC configuration for **all functions** added in the service will be added in `provider`.
+
+See more [VPC Configuration](https://www.serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration)
+
+```js
+process.env.LAMBDA_SECURITY_GROUP_ID = 'sg-abcdef0001';
+process.env.LAMBDA_SUBNET_IDS = 'subnet-111111111,subnet-222222222';
+```
+
 ## Full example
 
 ```js

--- a/lib/service/authorizers.js
+++ b/lib/service/authorizers.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { inspect } = require('util');
-
 const defaultAuthorizers = require('./default-authorizers');
 
 const authorizersNameToFunctionMapping = {
@@ -32,7 +30,7 @@ module.exports = ({ custom, ...serviceConfig }) => {
 	const accountId = process.env.AUTHORIZER_ACCOUNT_ID;
 
 	if(!accountId || typeof accountId !== 'string')
-		throw new Error(`Missing or invalid accountId in janis.authorizers hook: ${inspect(accountId)}`);
+		throw new Error('Missing or invalid accountId for janis.authorizers hook, validate env variable AUTHORIZER_ACCOUNT_ID');
 
 	const customAuthorizers = (custom && custom.authorizers) || {};
 

--- a/lib/service/authorizers.js
+++ b/lib/service/authorizers.js
@@ -27,7 +27,9 @@ const buildAuthorizers = accountId => {
 	}, {});
 };
 
-module.exports = ({ custom, ...serviceConfig }, { accountId }) => {
+module.exports = ({ custom, ...serviceConfig }) => {
+
+	const accountId = process.env.AUTHORIZER_ACCOUNT_ID;
 
 	if(!accountId || typeof accountId !== 'string')
 		throw new Error(`Missing or invalid accountId in janis.authorizers hook: ${inspect(accountId)}`);

--- a/lib/service/base.js
+++ b/lib/service/base.js
@@ -7,6 +7,7 @@ const kebabcase = require('../utils/kebabcase');
 
 const { LOG_FORMAT, LOG_REST_API_CONFIG } = require('../utils/api-gateway-logs-defaults');
 const { shouldAddTraceLayer, getTraceLayerArn } = require('../utils/trace-layer');
+const { shouldAddVPCConfig, getVPCConfig } = require('../utils/vpc');
 
 const defaultInclude = [
 	'src/config/*',
@@ -168,6 +169,7 @@ module.exports = ({
 				}
 			},
 			...layers.length ? { layers } : {},
+			...shouldAddVPCConfig() && { vpc: getVPCConfig() },
 			...(provider || {})
 		},
 		params: {

--- a/lib/utils/vpc.js
+++ b/lib/utils/vpc.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.shouldAddVPCConfig = () => process.env.LAMBDA_SECURITY_GROUP_ID && process.env.LAMBDA_SUBNET_IDS;
+
+module.exports.getVPCConfig = () => ({
+	securityGroupIds: [process.env.LAMBDA_SECURITY_GROUP_ID],
+	subnetIds: process.env.LAMBDA_SUBNET_IDS.replace(/\s/g, '').split(',')
+});

--- a/tests/unit/hooks/authorizers.js
+++ b/tests/unit/hooks/authorizers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert').strict;
+const sinon = require('sinon');
 
 const { authorizers } = require('../../..');
 
@@ -130,14 +131,22 @@ describe('Hooks', () => {
 			}
 		};
 
-		it('Should throw if accountId is not passed', () => {
+		const originalEnvs = { ...process.env };
 
-			assert.throws(() => authorizers({}, {}));
+		afterEach(() => {
+			process.env = { ...originalEnvs };
+			sinon.restore();
+		});
+
+		it('Should throw if accountId is not set in env var', () => {
+			assert.throws(() => authorizers({}));
 		});
 
 		it('Should return the authorizers service configuration', () => {
 
-			const serviceConfig = authorizers({}, { accountId });
+			process.env.AUTHORIZER_ACCOUNT_ID = accountId;
+
+			const serviceConfig = authorizers({});
 
 			assert.deepStrictEqual(serviceConfig, {
 				custom: {
@@ -148,13 +157,15 @@ describe('Hooks', () => {
 
 		it('Should return the authorizers service configuration maintaining previous authorizers', () => {
 
+			process.env.AUTHORIZER_ACCOUNT_ID = accountId;
+
 			const serviceConfig = authorizers({
 				custom: {
 					authorizers: {
 						MyCustomAuthorizer: {}
 					}
 				}
-			}, { accountId });
+			});
 
 			assert.deepStrictEqual(serviceConfig, {
 				custom: {
@@ -168,11 +179,13 @@ describe('Hooks', () => {
 
 		it('Should not override other configurations', () => {
 
+			process.env.AUTHORIZER_ACCOUNT_ID = accountId;
+
 			const serviceConfig = authorizers({
 				custom: {
 					foo: 'bar'
 				}
-			}, { accountId });
+			});
 
 			assert.deepStrictEqual(serviceConfig, {
 				custom: {

--- a/tests/unit/hooks/authorizers.js
+++ b/tests/unit/hooks/authorizers.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('assert').strict;
-const sinon = require('sinon');
 
 const { authorizers } = require('../../..');
 
@@ -135,7 +134,6 @@ describe('Hooks', () => {
 
 		afterEach(() => {
 			process.env = { ...originalEnvs };
-			sinon.restore();
 		});
 
 		it('Should throw if accountId is not set in env var', () => {

--- a/tests/unit/hooks/base.js
+++ b/tests/unit/hooks/base.js
@@ -11,45 +11,448 @@ describe('Hooks', () => {
 
 	describe('Base service', () => {
 
+		const originalEnvs = { ...process.env };
+
+		afterEach(() => {
+			process.env = { ...originalEnvs };
+			sinon.restore();
+		});
+
 		const validServicePort = 3000;
+		const validServiceCode = 'testing';
 
-		it('Should throw if serviceCode hook config is not defined', () => {
-			assert.throws(() => base({}, {
-				servicePort: validServicePort
-			}));
-		});
+		const expectedConfig = {
+			service: 'Janis${self:custom.serviceName}Service',
+			provider: {
+				name: 'aws',
+				runtime: 'nodejs18.x',
+				memorySize: 1024,
+				stage: '${opt:stage, \'local\'}',
+				region: '${opt:region, \'us-east-1\'}',
+				role: 'ServiceExecutionRole',
+				endpointType: 'REGIONAL',
+				apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
+				logRetentionInDays: 14,
+				environment: {
+					JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+					JANIS_ENV: '${self:custom.stage}',
+					MS_PATH: 'src'
+				},
+				tags: {
+					Owner: 'Janis',
+					Microservice: '${self:custom.serviceName}',
+					Stack: '${param:humanReadableStage}'
+				},
+				versionFunctions: false,
+				apiGateway: {
+					disableDefaultEndpoint: true,
+					minimumCompressionSize: 1024
+				},
+				logs: {
+					restApi: {
+						accessLogging: true,
+						executionLogging: false,
+						level: 'INFO',
+						fullExecutionData: false,
+						format: JSON.stringify({
+							date: '$context.requestTime',
+							reqId: '$context.requestId',
+							integReqId: '$context.integration.requestId',
+							ip: '$context.identity.sourceIp',
+							ua: '$context.identity.userAgent',
+							clientCode: '$context.authorizer.clientCode',
+							principalId: '$context.authorizer.principalId',
+							reqMethod: '$context.httpMethod',
+							path: '$context.resourcePath',
+							realPath: '$context.path',
+							status: '$context.status',
+							authTime: '$context.authorizer.latency',
+							resTime: '$context.responseLatency',
+							gwError: '$context.error.message',
+							integError: '$context.integration.error'
+						})
+					}
+				}
+			},
+			params: {
+				local: {
+					humanReadableStage: 'Local',
+					janisDomain: 'janis.localhost'
+				},
+				beta: {
+					humanReadableStage: 'Beta',
+					janisDomain: 'janisdev.in'
+				},
+				qa: {
+					janisDomain: 'janisqa.in',
+					humanReadableStage: 'QA'
+				},
+				prod: {
+					humanReadableStage: 'Prod',
+					janisDomain: 'janis.in'
+				}
+			},
+			package: {
+				individually: false,
+				include: [
+					'src/config/*',
+					'node_modules/@babel/runtime/**'
+				],
+				exclude: [
+					'.nyc_output/**',
+					'.bitbucket/**',
+					'.deploy/**',
+					'.husky/**',
+					'view-schemas/**',
+					'view-schemas-built/**',
+					'view-schemas-built-local/**',
+					'tests/**',
+					'test-reports/**',
+					'hooks/**',
+					'events/**',
+					'permissions/**',
+					'schemas/src/**',
+					'serverless/**',
+					'src/environments/**',
+					'*',
+					'.*',
+					'node_modules/.cache/**',
+					'node_modules/**/README.md',
+					'node_modules/**/.github/**',
+					'node_modules/**/CHANGELOG.md',
+					'node_modules/**/LICENSE',
+					'node_modules/**/*.js.map',
+					'node_modules/**/*.map',
+					'node_modules/**/*.min.map',
+					'node_modules/**/*.js.flow',
+					'node_modules/**/*.d.ts',
+					'node_modules/function.prototype.name/**',
+					'node_modules/which-typed-array/**',
+					'node_modules/is-typed-array/**',
+					'mongodb/src/**',
+					'bson/dist/**',
+					'bson/src/**',
+					'node_modules/@aws-sdk/**',
+					'node_modules/**/@aws-sdk/**',
+					'node_modules/sinon/**',
+					'node_modules/serverless/**',
+					'node_modules/@serverless/**',
+					'node_modules/@babel/**',
+					'node_modules/eslint-plugin-import/**',
+					'node_modules/@sinonjs/**',
+					'node_modules/faker/dist/**',
+					'node_modules/date-fns/esm/**',
+					'node_modules/date-fns/fp/**',
+					'node_modules/**/date-fns/docs/**',
+					'node_modules/**/buffer/test/**',
+					'node_modules/**/jmespath/test/**',
+					'node_modules/**/qs/test/**',
+					'node_modules/**/qs/dist/**',
+					'node_modules/**/bson/browser_build/**',
+					'node_modules/**/axios/dist/browser/**',
+					'node_modules/**/axios/dist/esm/**'
+				]
+			},
+			custom: {
+				serviceTitle: 'Testing',
+				serviceName: 'Testing',
+				serviceCode: 'testing',
+				stage: '${self:provider.stage}',
+				region: '${self:provider.region}',
 
-		it('Should throw if serviceCode hook config is not a string', () => {
-			assert.throws(() => base({}, {
-				serviceCode: ['invalid'],
-				servicePort: validServicePort
-			}));
-		});
+				humanReadableStage: {
+					local: 'Local',
+					beta: 'Beta',
+					qa: 'QA',
+					prod: 'Prod'
+				},
 
-		it('Should throw if serviceCode hook config is not in dash-case', () => {
+				janisDomains: {
+					local: 'janis.localhost',
+					beta: 'janisdev.in',
+					qa: 'janisqa.in',
+					prod: 'janis.in'
+				},
 
-			[
-				'SomeInvalidCode',
-				'Some Invalid Code'
-			].forEach(serviceCode => {
+				cacheEnabled: {
+					prod: false
+				},
+
+				customDomain: {
+					domainName: '${self:custom.serviceCode}.${param:janisDomain}',
+					basePath: 'api',
+					stage: '${self:custom.stage}',
+					createRoute53Record: true,
+					endpointType: 'regional',
+					securityPolicy: 'tls_1_2'
+				},
+
+				apiGatewayCaching: {
+					enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
+					clusterSize: '0.5',
+					ttlInSeconds: 600 // 10 minutos
+				},
+
+				'serverless-offline': {
+					httpPort: 3000,
+					lambdaPort: 23000,
+					host: '0.0.0.0',
+					stage: 'local',
+					noPrependStageInUrl: true,
+					prefix: 'api',
+					reloadHandler: true
+				},
+
+				stageVariables: {
+					serviceName: '${self:custom.serviceCode}'
+				},
+
+				reducer: {
+					ignoreMissing: true
+				}
+			},
+			plugins: [
+				'serverless-domain-manager',
+				'serverless-offline',
+				'serverless-api-gateway-caching',
+				'serverless-plugin-stage-variables',
+				'@janiscommerce/serverless-plugin-remove-authorizer-permissions',
+				'serverless-plugin-split-stacks'
+			],
+			resources: {
+				Resources: {
+
+					ServiceExecutionRole: {
+						Type: 'AWS::IAM::Role',
+						Properties: {
+							RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
+							Path: '/janis-service/',
+							AssumeRolePolicyDocument: {
+								Version: '2012-10-17',
+								Statement: [
+									{
+										Effect: 'Allow',
+										Principal: {
+											Service: [
+												'lambda.amazonaws.com'
+											]
+										},
+										Action: 'sts:AssumeRole'
+									}
+								]
+							},
+							ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
+							Policies: [
+								{
+									PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
+									PolicyDocument: {
+										Version: '2012-10-17',
+										Statement: [
+											{
+												Effect: 'Allow',
+												Action: [
+													'logs:CreateLogGroup',
+													'logs:CreateLogStream',
+													'logs:PutLogEvents'
+												],
+												Resource: [
+													{
+														'Fn::Join': [
+															':',
+															[
+																'arn:aws:logs',
+																{ Ref: 'AWS::Region' },
+																{ Ref: 'AWS::AccountId' },
+																'log-group:/aws/lambda/*:*'
+															]
+														]
+													},
+													{
+														'Fn::Join': [
+															':',
+															[
+																'arn:aws:logs',
+																{ Ref: 'AWS::Region' },
+																{ Ref: 'AWS::AccountId' },
+																'log-group:/aws/lambda/*:*:*'
+															]
+														]
+													}
+												]
+											}
+										]
+									}
+								}
+							]
+						}
+					},
+
+					UnauthorizedResponse: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'UNAUTHORIZED',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '401'
+						}
+					},
+
+					BadRequestBodyResponse: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'BAD_REQUEST_BODY',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '400'
+						}
+					},
+
+					BadRequestParameters: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'BAD_REQUEST_PARAMETERS',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '400'
+						}
+					},
+
+					AccessDeniedResponse: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'ACCESS_DENIED',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '403'
+						}
+					},
+
+					AuthorizerConfigurationErrorResponse: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '500'
+						}
+					},
+
+					AuthorizerFailureResponse: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'AUTHORIZER_FAILURE',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '500'
+						}
+					},
+
+					IntegrationTimeoutResponse: {
+						Type: 'AWS::ApiGateway::GatewayResponse',
+						Properties: {
+							ResponseParameters: {
+								'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
+							},
+							ResponseTemplates: {
+								'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
+							},
+							ResponseType: 'INTEGRATION_TIMEOUT',
+							RestApiId: {
+								Ref: 'ApiGatewayRestApi'
+							},
+							StatusCode: '504'
+						}
+					}
+
+				}
+			}
+		};
+
+		context('When required config is missing', () => {
+
+			it('Should throw if serviceCode hook config is not defined', () => {
 				assert.throws(() => base({}, {
-					serviceCode,
 					servicePort: validServicePort
+				}));
+			});
+
+			it('Should throw if servicePort hook config is not defined', () => {
+				assert.throws(() => base({}, {
+					serviceCode: validServiceCode
 				}));
 			});
 		});
 
-		it('Should throw if servicePort hook config is not defined', () => {
-			assert.throws(() => base({}, {
-				serviceCode: 'testing'
-			}));
-		});
+		context('When invalid config received', () => {
 
-		it('Should throw if servicePort hook config is not a string', () => {
-			assert.throws(() => base({}, {
-				serviceCode: 'testing',
-				servicePort: ['invalid']
-			}));
+			it('Should throw if serviceCode hook config is not a string', () => {
+				assert.throws(() => base({}, {
+					serviceCode: ['invalid'],
+					servicePort: validServicePort
+				}));
+			});
+
+			it('Should throw if serviceCode hook config is not in dash-case', () => {
+
+				[
+					'SomeInvalidCode',
+					'Some Invalid Code'
+				].forEach(serviceCode => {
+					assert.throws(() => base({}, {
+						serviceCode,
+						servicePort: validServicePort
+					}));
+				});
+			});
+
+			it('Should throw if servicePort hook config is not a string', () => {
+				assert.throws(() => base({}, {
+					serviceCode: validServiceCode,
+					servicePort: ['invalid']
+				}));
+			});
 		});
 
 		it('Should not throw if a valid serviceCode and servicePort is received', () => {
@@ -72,398 +475,11 @@ describe('Hooks', () => {
 		it('Should return the base service configuration', () => {
 
 			const serviceConfig = base({}, {
-				serviceCode: 'testing',
+				serviceCode: validServiceCode,
 				servicePort: validServicePort
 			});
 
-			assert.deepStrictEqual(serviceConfig, {
-				service: 'Janis${self:custom.serviceName}Service',
-				provider: {
-					name: 'aws',
-					runtime: 'nodejs18.x',
-					memorySize: 1024,
-					stage: '${opt:stage, \'local\'}',
-					region: '${opt:region, \'us-east-1\'}',
-					role: 'ServiceExecutionRole',
-					endpointType: 'REGIONAL',
-					apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
-					logRetentionInDays: 14,
-					environment: {
-						JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-						JANIS_ENV: '${self:custom.stage}',
-						MS_PATH: 'src'
-					},
-					tags: {
-						Owner: 'Janis',
-						Microservice: '${self:custom.serviceName}',
-						Stack: '${param:humanReadableStage}'
-					},
-					versionFunctions: false,
-					apiGateway: {
-						disableDefaultEndpoint: true,
-						minimumCompressionSize: 1024
-					},
-					logs: {
-						restApi: {
-							accessLogging: true,
-							executionLogging: false,
-							level: 'INFO',
-							fullExecutionData: false,
-							format: JSON.stringify({
-								date: '$context.requestTime',
-								reqId: '$context.requestId',
-								integReqId: '$context.integration.requestId',
-								ip: '$context.identity.sourceIp',
-								ua: '$context.identity.userAgent',
-								clientCode: '$context.authorizer.clientCode',
-								principalId: '$context.authorizer.principalId',
-								reqMethod: '$context.httpMethod',
-								path: '$context.resourcePath',
-								realPath: '$context.path',
-								status: '$context.status',
-								authTime: '$context.authorizer.latency',
-								resTime: '$context.responseLatency',
-								gwError: '$context.error.message',
-								integError: '$context.integration.error'
-							})
-						}
-					}
-				},
-				params: {
-					local: {
-						humanReadableStage: 'Local',
-						janisDomain: 'janis.localhost'
-					},
-					beta: {
-						humanReadableStage: 'Beta',
-						janisDomain: 'janisdev.in'
-					},
-					qa: {
-						janisDomain: 'janisqa.in',
-						humanReadableStage: 'QA'
-					},
-					prod: {
-						humanReadableStage: 'Prod',
-						janisDomain: 'janis.in'
-					}
-				},
-				package: {
-					individually: false,
-					include: [
-						'src/config/*',
-						'node_modules/@babel/runtime/**'
-					],
-					exclude: [
-						'.nyc_output/**',
-						'.bitbucket/**',
-						'.deploy/**',
-						'.husky/**',
-						'view-schemas/**',
-						'view-schemas-built/**',
-						'view-schemas-built-local/**',
-						'tests/**',
-						'test-reports/**',
-						'hooks/**',
-						'events/**',
-						'permissions/**',
-						'schemas/src/**',
-						'serverless/**',
-						'src/environments/**',
-						'*',
-						'.*',
-						'node_modules/.cache/**',
-						'node_modules/**/README.md',
-						'node_modules/**/.github/**',
-						'node_modules/**/CHANGELOG.md',
-						'node_modules/**/LICENSE',
-						'node_modules/**/*.js.map',
-						'node_modules/**/*.map',
-						'node_modules/**/*.min.map',
-						'node_modules/**/*.js.flow',
-						'node_modules/**/*.d.ts',
-						'node_modules/function.prototype.name/**',
-						'node_modules/which-typed-array/**',
-						'node_modules/is-typed-array/**',
-						'mongodb/src/**',
-						'bson/dist/**',
-						'bson/src/**',
-						'node_modules/@aws-sdk/**',
-						'node_modules/**/@aws-sdk/**',
-						'node_modules/sinon/**',
-						'node_modules/serverless/**',
-						'node_modules/@serverless/**',
-						'node_modules/@babel/**',
-						'node_modules/eslint-plugin-import/**',
-						'node_modules/@sinonjs/**',
-						'node_modules/faker/dist/**',
-						'node_modules/date-fns/esm/**',
-						'node_modules/date-fns/fp/**',
-						'node_modules/**/date-fns/docs/**',
-						'node_modules/**/buffer/test/**',
-						'node_modules/**/jmespath/test/**',
-						'node_modules/**/qs/test/**',
-						'node_modules/**/qs/dist/**',
-						'node_modules/**/bson/browser_build/**',
-						'node_modules/**/axios/dist/browser/**',
-						'node_modules/**/axios/dist/esm/**'
-					]
-				},
-				custom: {
-					serviceTitle: 'Testing',
-					serviceName: 'Testing',
-					serviceCode: 'testing',
-					stage: '${self:provider.stage}',
-					region: '${self:provider.region}',
-
-					humanReadableStage: {
-						local: 'Local',
-						beta: 'Beta',
-						qa: 'QA',
-						prod: 'Prod'
-					},
-
-					janisDomains: {
-						local: 'janis.localhost',
-						beta: 'janisdev.in',
-						qa: 'janisqa.in',
-						prod: 'janis.in'
-					},
-
-					cacheEnabled: {
-						prod: false
-					},
-
-					customDomain: {
-						domainName: '${self:custom.serviceCode}.${param:janisDomain}',
-						basePath: 'api',
-						stage: '${self:custom.stage}',
-						createRoute53Record: true,
-						endpointType: 'regional',
-						securityPolicy: 'tls_1_2'
-					},
-
-					apiGatewayCaching: {
-						enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
-						clusterSize: '0.5',
-						ttlInSeconds: 600 // 10 minutos
-					},
-
-					'serverless-offline': {
-						httpPort: 3000,
-						lambdaPort: 23000,
-						host: '0.0.0.0',
-						stage: 'local',
-						noPrependStageInUrl: true,
-						prefix: 'api',
-						reloadHandler: true
-					},
-
-					stageVariables: {
-						serviceName: '${self:custom.serviceCode}'
-					},
-
-					reducer: {
-						ignoreMissing: true
-					}
-				},
-				plugins: [
-					'serverless-domain-manager',
-					'serverless-offline',
-					'serverless-api-gateway-caching',
-					'serverless-plugin-stage-variables',
-					'@janiscommerce/serverless-plugin-remove-authorizer-permissions',
-					'serverless-plugin-split-stacks'
-				],
-				resources: {
-					Resources: {
-
-						ServiceExecutionRole: {
-							Type: 'AWS::IAM::Role',
-							Properties: {
-								RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
-								Path: '/janis-service/',
-								AssumeRolePolicyDocument: {
-									Version: '2012-10-17',
-									Statement: [
-										{
-											Effect: 'Allow',
-											Principal: {
-												Service: [
-													'lambda.amazonaws.com'
-												]
-											},
-											Action: 'sts:AssumeRole'
-										}
-									]
-								},
-								ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
-								Policies: [
-									{
-										PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
-										PolicyDocument: {
-											Version: '2012-10-17',
-											Statement: [
-												{
-													Effect: 'Allow',
-													Action: [
-														'logs:CreateLogGroup',
-														'logs:CreateLogStream',
-														'logs:PutLogEvents'
-													],
-													Resource: [
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*'
-																]
-															]
-														},
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*:*'
-																]
-															]
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							}
-						},
-
-						UnauthorizedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'UNAUTHORIZED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '401'
-							}
-						},
-
-						BadRequestBodyResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_BODY',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						BadRequestParameters: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_PARAMETERS',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						AccessDeniedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'ACCESS_DENIED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '403'
-							}
-						},
-
-						AuthorizerConfigurationErrorResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						AuthorizerFailureResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_FAILURE',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						IntegrationTimeoutResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'INTEGRATION_TIMEOUT',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '504'
-							}
-						}
-
-					}
-				}
-			});
+			assert.deepStrictEqual(serviceConfig, expectedConfig);
 		});
 
 		it('Should not override the original configuration', () => {
@@ -491,406 +507,21 @@ describe('Hooks', () => {
 					'some-custom-plugin'
 				]
 			}, {
-				serviceCode: 'testing',
+				serviceCode: validServiceCode,
 				servicePort: validServicePort
 			});
 
-			assert.deepStrictEqual(serviceConfig, {
-				service: 'Janis${self:custom.serviceName}Service',
-				provider: {
-					name: 'aws',
-					runtime: 'nodejs18.x',
-					memorySize: 1024,
-					stage: '${opt:stage, \'local\'}',
-					region: '${opt:region, \'us-east-1\'}',
-					role: 'ServiceExecutionRole',
-					endpointType: 'REGIONAL',
-					apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
-					logRetentionInDays: 30,
-					environment: {
-						JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-						JANIS_ENV: '${self:custom.stage}',
-						MS_PATH: 'src'
-					},
-					tags: {
-						Owner: 'Janis',
-						Microservice: '${self:custom.serviceName}',
-						Stack: '${param:humanReadableStage}'
-					},
-					versionFunctions: false,
-					apiGateway: {
-						disableDefaultEndpoint: true,
-						minimumCompressionSize: 1024
-					},
-					logs: {
-						restApi: {
-							accessLogging: true,
-							executionLogging: false,
-							level: 'INFO',
-							fullExecutionData: false,
-							format: JSON.stringify({
-								date: '$context.requestTime',
-								reqId: '$context.requestId',
-								integReqId: '$context.integration.requestId',
-								ip: '$context.identity.sourceIp',
-								ua: '$context.identity.userAgent',
-								clientCode: '$context.authorizer.clientCode',
-								principalId: '$context.authorizer.principalId',
-								reqMethod: '$context.httpMethod',
-								path: '$context.resourcePath',
-								realPath: '$context.path',
-								status: '$context.status',
-								authTime: '$context.authorizer.latency',
-								resTime: '$context.responseLatency',
-								gwError: '$context.error.message',
-								integError: '$context.integration.error'
-							})
-						}
-					}
-				},
-				params: {
-					local: {
-						humanReadableStage: 'Local',
-						janisDomain: 'janis.localhost'
-					},
-					beta: {
-						humanReadableStage: 'Beta',
-						janisDomain: 'janisdev.in'
-					},
-					qa: {
-						janisDomain: 'janisqa.in',
-						humanReadableStage: 'QA'
-					},
-					prod: {
-						humanReadableStage: 'Prod',
-						janisDomain: 'janis.in'
-					}
-				},
-				package: {
-					individually: false,
-					include: [
-						'src/config/*',
-						'node_modules/@babel/runtime/**',
-						'custom/path/**'
-					],
-					exclude: [
-						'.nyc_output/**',
-						'.bitbucket/**',
-						'.deploy/**',
-						'.husky/**',
-						'view-schemas/**',
-						'view-schemas-built/**',
-						'view-schemas-built-local/**',
-						'tests/**',
-						'test-reports/**',
-						'hooks/**',
-						'events/**',
-						'permissions/**',
-						'schemas/src/**',
-						'serverless/**',
-						'src/environments/**',
-						'*',
-						'.*',
-						'node_modules/.cache/**',
-						'node_modules/**/README.md',
-						'node_modules/**/.github/**',
-						'node_modules/**/CHANGELOG.md',
-						'node_modules/**/LICENSE',
-						'node_modules/**/*.js.map',
-						'node_modules/**/*.map',
-						'node_modules/**/*.min.map',
-						'node_modules/**/*.js.flow',
-						'node_modules/**/*.d.ts',
-						'node_modules/function.prototype.name/**',
-						'node_modules/which-typed-array/**',
-						'node_modules/is-typed-array/**',
-						'mongodb/src/**',
-						'bson/dist/**',
-						'bson/src/**',
-						'node_modules/@aws-sdk/**',
-						'node_modules/**/@aws-sdk/**',
-						'node_modules/sinon/**',
-						'node_modules/serverless/**',
-						'node_modules/@serverless/**',
-						'node_modules/@babel/**',
-						'node_modules/eslint-plugin-import/**',
-						'node_modules/@sinonjs/**',
-						'node_modules/faker/dist/**',
-						'node_modules/date-fns/esm/**',
-						'node_modules/date-fns/fp/**',
-						'node_modules/**/date-fns/docs/**',
-						'node_modules/**/buffer/test/**',
-						'node_modules/**/jmespath/test/**',
-						'node_modules/**/qs/test/**',
-						'node_modules/**/qs/dist/**',
-						'node_modules/**/bson/browser_build/**',
-						'node_modules/**/axios/dist/browser/**',
-						'node_modules/**/axios/dist/esm/**',
-						'something'
-					]
-				},
-				custom: {
-					serviceTitle: 'Testing',
-					serviceName: 'Testing',
-					serviceCode: 'testing',
-					stage: '${self:provider.stage}',
-					region: '${self:provider.region}',
+			const clonedExpectedConfig = JSON.parse(JSON.stringify(expectedConfig));
 
-					humanReadableStage: {
-						local: 'Local',
-						beta: 'Beta',
-						qa: 'QA',
-						prod: 'Prod'
-					},
+			clonedExpectedConfig.provider.logRetentionInDays = 30;
+			clonedExpectedConfig.custom.myCustomProp = { foo: 'bar' };
+			clonedExpectedConfig.anotherProp = true;
+			clonedExpectedConfig.package.individually = false;
+			clonedExpectedConfig.package.include.push('custom/path/**');
+			clonedExpectedConfig.package.exclude.push('something');
+			clonedExpectedConfig.plugins.push('some-custom-plugin');
 
-					janisDomains: {
-						local: 'janis.localhost',
-						beta: 'janisdev.in',
-						qa: 'janisqa.in',
-						prod: 'janis.in'
-					},
-
-					cacheEnabled: {
-						prod: false
-					},
-
-					customDomain: {
-						domainName: '${self:custom.serviceCode}.${param:janisDomain}',
-						basePath: 'api',
-						stage: '${self:custom.stage}',
-						createRoute53Record: true,
-						endpointType: 'regional',
-						securityPolicy: 'tls_1_2'
-					},
-
-					apiGatewayCaching: {
-						enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
-						clusterSize: '0.5',
-						ttlInSeconds: 600 // 10 minutos
-					},
-
-					'serverless-offline': {
-						httpPort: 3000,
-						lambdaPort: 23000,
-						host: '0.0.0.0',
-						stage: 'local',
-						noPrependStageInUrl: true,
-						prefix: 'api',
-						reloadHandler: true
-					},
-
-					stageVariables: {
-						serviceName: '${self:custom.serviceCode}'
-					},
-
-					reducer: {
-						ignoreMissing: true
-					},
-
-					myCustomProp: {
-						foo: 'bar'
-					}
-				},
-				anotherProp: true,
-
-				plugins: [
-					'serverless-domain-manager',
-					'serverless-offline',
-					'serverless-api-gateway-caching',
-					'serverless-plugin-stage-variables',
-					'@janiscommerce/serverless-plugin-remove-authorizer-permissions',
-					'serverless-plugin-split-stacks',
-					'some-custom-plugin'
-				],
-				resources: {
-					Resources: {
-
-						ServiceExecutionRole: {
-							Type: 'AWS::IAM::Role',
-							Properties: {
-								RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
-								Path: '/janis-service/',
-								AssumeRolePolicyDocument: {
-									Version: '2012-10-17',
-									Statement: [
-										{
-											Effect: 'Allow',
-											Principal: {
-												Service: [
-													'lambda.amazonaws.com'
-												]
-											},
-											Action: 'sts:AssumeRole'
-										}
-									]
-								},
-								ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
-								Policies: [
-									{
-										PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
-										PolicyDocument: {
-											Version: '2012-10-17',
-											Statement: [
-												{
-													Effect: 'Allow',
-													Action: [
-														'logs:CreateLogGroup',
-														'logs:CreateLogStream',
-														'logs:PutLogEvents'
-													],
-													Resource: [
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*'
-																]
-															]
-														},
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*:*'
-																]
-															]
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							}
-						},
-
-						UnauthorizedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'UNAUTHORIZED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '401'
-							}
-						},
-
-						BadRequestBodyResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_BODY',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						BadRequestParameters: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_PARAMETERS',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						AccessDeniedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'ACCESS_DENIED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '403'
-							}
-						},
-
-						AuthorizerConfigurationErrorResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						AuthorizerFailureResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_FAILURE',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						IntegrationTimeoutResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'INTEGRATION_TIMEOUT',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '504'
-							}
-						}
-					}
-				}
-			});
+			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
 		});
 
 		it('Should use original configuration to override hook defaults', () => {
@@ -900,411 +531,20 @@ describe('Hooks', () => {
 					memorySize: 512
 				}
 			}, {
-				serviceCode: 'testing',
+				serviceCode: validServiceCode,
 				servicePort: validServicePort
 			});
 
-			assert.deepStrictEqual(serviceConfig, {
-				service: 'Janis${self:custom.serviceName}Service',
-				provider: {
-					name: 'aws',
-					runtime: 'nodejs18.x',
-					memorySize: 512,
-					stage: '${opt:stage, \'local\'}',
-					region: '${opt:region, \'us-east-1\'}',
-					role: 'ServiceExecutionRole',
-					endpointType: 'REGIONAL',
-					apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
-					logRetentionInDays: 14,
-					environment: {
-						JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-						JANIS_ENV: '${self:custom.stage}',
-						MS_PATH: 'src'
-					},
-					tags: {
-						Owner: 'Janis',
-						Microservice: '${self:custom.serviceName}',
-						Stack: '${param:humanReadableStage}'
-					},
-					versionFunctions: false,
-					apiGateway: {
-						disableDefaultEndpoint: true,
-						minimumCompressionSize: 1024
-					},
-					logs: {
-						restApi: {
-							accessLogging: true,
-							executionLogging: false,
-							level: 'INFO',
-							fullExecutionData: false,
-							format: JSON.stringify({
-								date: '$context.requestTime',
-								reqId: '$context.requestId',
-								integReqId: '$context.integration.requestId',
-								ip: '$context.identity.sourceIp',
-								ua: '$context.identity.userAgent',
-								clientCode: '$context.authorizer.clientCode',
-								principalId: '$context.authorizer.principalId',
-								reqMethod: '$context.httpMethod',
-								path: '$context.resourcePath',
-								realPath: '$context.path',
-								status: '$context.status',
-								authTime: '$context.authorizer.latency',
-								resTime: '$context.responseLatency',
-								gwError: '$context.error.message',
-								integError: '$context.integration.error'
-							})
-						}
-					}
-				},
-				params: {
-					local: {
-						humanReadableStage: 'Local',
-						janisDomain: 'janis.localhost'
-					},
-					beta: {
-						humanReadableStage: 'Beta',
-						janisDomain: 'janisdev.in'
-					},
-					qa: {
-						janisDomain: 'janisqa.in',
-						humanReadableStage: 'QA'
-					},
-					prod: {
-						humanReadableStage: 'Prod',
-						janisDomain: 'janis.in'
-					}
-				},
-				package: {
-					individually: false,
-					include: [
-						'src/config/*',
-						'node_modules/@babel/runtime/**'
-					],
-					exclude: [
-						'.nyc_output/**',
-						'.bitbucket/**',
-						'.deploy/**',
-						'.husky/**',
-						'view-schemas/**',
-						'view-schemas-built/**',
-						'view-schemas-built-local/**',
-						'tests/**',
-						'test-reports/**',
-						'hooks/**',
-						'events/**',
-						'permissions/**',
-						'schemas/src/**',
-						'serverless/**',
-						'src/environments/**',
-						'*',
-						'.*',
-						'node_modules/.cache/**',
-						'node_modules/**/README.md',
-						'node_modules/**/.github/**',
-						'node_modules/**/CHANGELOG.md',
-						'node_modules/**/LICENSE',
-						'node_modules/**/*.js.map',
-						'node_modules/**/*.map',
-						'node_modules/**/*.min.map',
-						'node_modules/**/*.js.flow',
-						'node_modules/**/*.d.ts',
-						'node_modules/function.prototype.name/**',
-						'node_modules/which-typed-array/**',
-						'node_modules/is-typed-array/**',
-						'mongodb/src/**',
-						'bson/dist/**',
-						'bson/src/**',
-						'node_modules/@aws-sdk/**',
-						'node_modules/**/@aws-sdk/**',
-						'node_modules/sinon/**',
-						'node_modules/serverless/**',
-						'node_modules/@serverless/**',
-						'node_modules/@babel/**',
-						'node_modules/eslint-plugin-import/**',
-						'node_modules/@sinonjs/**',
-						'node_modules/faker/dist/**',
-						'node_modules/date-fns/esm/**',
-						'node_modules/date-fns/fp/**',
-						'node_modules/**/date-fns/docs/**',
-						'node_modules/**/buffer/test/**',
-						'node_modules/**/jmespath/test/**',
-						'node_modules/**/qs/test/**',
-						'node_modules/**/qs/dist/**',
-						'node_modules/**/bson/browser_build/**',
-						'node_modules/**/axios/dist/browser/**',
-						'node_modules/**/axios/dist/esm/**'
-					]
-				},
-				custom: {
-					serviceTitle: 'Testing',
-					serviceName: 'Testing',
-					serviceCode: 'testing',
-					stage: '${self:provider.stage}',
-					region: '${self:provider.region}',
+			const clonedExpectedConfig = JSON.parse(JSON.stringify(expectedConfig));
 
-					humanReadableStage: {
-						local: 'Local',
-						beta: 'Beta',
-						qa: 'QA',
-						prod: 'Prod'
-					},
+			clonedExpectedConfig.provider.memorySize = 512;
 
-					janisDomains: {
-						local: 'janis.localhost',
-						beta: 'janisdev.in',
-						qa: 'janisqa.in',
-						prod: 'janis.in'
-					},
-
-					cacheEnabled: {
-						prod: false
-					},
-
-					customDomain: {
-						domainName: '${self:custom.serviceCode}.${param:janisDomain}',
-						basePath: 'api',
-						stage: '${self:custom.stage}',
-						createRoute53Record: true,
-						endpointType: 'regional',
-						securityPolicy: 'tls_1_2'
-					},
-
-					apiGatewayCaching: {
-						enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
-						clusterSize: '0.5',
-						ttlInSeconds: 600 // 10 minutos
-					},
-
-					'serverless-offline': {
-						httpPort: 3000,
-						lambdaPort: 23000,
-						host: '0.0.0.0',
-						stage: 'local',
-						noPrependStageInUrl: true,
-						prefix: 'api',
-						reloadHandler: true
-					},
-
-					stageVariables: {
-						serviceName: '${self:custom.serviceCode}'
-					},
-
-					reducer: {
-						ignoreMissing: true
-					}
-				},
-				plugins: [
-					'serverless-domain-manager',
-					'serverless-offline',
-					'serverless-api-gateway-caching',
-					'serverless-plugin-stage-variables',
-					'@janiscommerce/serverless-plugin-remove-authorizer-permissions',
-					'serverless-plugin-split-stacks'
-				],
-				resources: {
-					Resources: {
-
-						ServiceExecutionRole: {
-							Type: 'AWS::IAM::Role',
-							Properties: {
-								RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
-								Path: '/janis-service/',
-								AssumeRolePolicyDocument: {
-									Version: '2012-10-17',
-									Statement: [
-										{
-											Effect: 'Allow',
-											Principal: {
-												Service: [
-													'lambda.amazonaws.com'
-												]
-											},
-											Action: 'sts:AssumeRole'
-										}
-									]
-								},
-								ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
-								Policies: [
-									{
-										PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
-										PolicyDocument: {
-											Version: '2012-10-17',
-											Statement: [
-												{
-													Effect: 'Allow',
-													Action: [
-														'logs:CreateLogGroup',
-														'logs:CreateLogStream',
-														'logs:PutLogEvents'
-													],
-													Resource: [
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*'
-																]
-															]
-														},
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*:*'
-																]
-															]
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							}
-						},
-
-						UnauthorizedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'UNAUTHORIZED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '401'
-							}
-						},
-
-						BadRequestBodyResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_BODY',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						BadRequestParameters: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_PARAMETERS',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						AccessDeniedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'ACCESS_DENIED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '403'
-							}
-						},
-
-						AuthorizerConfigurationErrorResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						AuthorizerFailureResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_FAILURE',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						IntegrationTimeoutResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'INTEGRATION_TIMEOUT',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '504'
-							}
-						}
-					}
-				}
-			});
+			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
 		});
 
 		it('Should override the original configuration for xxxOnly configurations', () => {
 
 			const serviceConfig = base({
-				provider: {
-					logRetentionInDays: 30
-				},
-				custom: {
-					myCustomProp: {
-						foo: 'bar'
-					}
-				},
-				anotherProp: true,
 				package: {
 					includeOnly: [
 						'custom/path/**'
@@ -1317,754 +557,35 @@ describe('Hooks', () => {
 					'my-unique-plugin'
 				]
 			}, {
-				serviceCode: 'testing',
+				serviceCode: validServiceCode,
 				servicePort: validServicePort
 			});
 
-			assert.deepStrictEqual(serviceConfig, {
-				service: 'Janis${self:custom.serviceName}Service',
-				provider: {
-					name: 'aws',
-					runtime: 'nodejs18.x',
-					memorySize: 1024,
-					stage: '${opt:stage, \'local\'}',
-					region: '${opt:region, \'us-east-1\'}',
-					role: 'ServiceExecutionRole',
-					endpointType: 'REGIONAL',
-					apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
-					logRetentionInDays: 30,
-					environment: {
-						JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-						JANIS_ENV: '${self:custom.stage}',
-						MS_PATH: 'src'
-					},
-					tags: {
-						Owner: 'Janis',
-						Microservice: '${self:custom.serviceName}',
-						Stack: '${param:humanReadableStage}'
-					},
-					versionFunctions: false,
-					apiGateway: {
-						disableDefaultEndpoint: true,
-						minimumCompressionSize: 1024
-					},
-					logs: {
-						restApi: {
-							accessLogging: true,
-							executionLogging: false,
-							level: 'INFO',
-							fullExecutionData: false,
-							format: JSON.stringify({
-								date: '$context.requestTime',
-								reqId: '$context.requestId',
-								integReqId: '$context.integration.requestId',
-								ip: '$context.identity.sourceIp',
-								ua: '$context.identity.userAgent',
-								clientCode: '$context.authorizer.clientCode',
-								principalId: '$context.authorizer.principalId',
-								reqMethod: '$context.httpMethod',
-								path: '$context.resourcePath',
-								realPath: '$context.path',
-								status: '$context.status',
-								authTime: '$context.authorizer.latency',
-								resTime: '$context.responseLatency',
-								gwError: '$context.error.message',
-								integError: '$context.integration.error'
-							})
-						}
-					}
-				},
-				params: {
-					local: {
-						humanReadableStage: 'Local',
-						janisDomain: 'janis.localhost'
-					},
-					beta: {
-						humanReadableStage: 'Beta',
-						janisDomain: 'janisdev.in'
-					},
-					qa: {
-						janisDomain: 'janisqa.in',
-						humanReadableStage: 'QA'
-					},
-					prod: {
-						humanReadableStage: 'Prod',
-						janisDomain: 'janis.in'
-					}
-				},
-				package: {
-					individually: false,
-					include: [
-						'custom/path/**'
-					],
-					exclude: [
-						'something'
-					]
-				},
-				custom: {
-					serviceTitle: 'Testing',
-					serviceName: 'Testing',
-					serviceCode: 'testing',
-					stage: '${self:provider.stage}',
-					region: '${self:provider.region}',
+			const clonedExpectedConfig = JSON.parse(JSON.stringify(expectedConfig));
 
-					humanReadableStage: {
-						local: 'Local',
-						beta: 'Beta',
-						qa: 'QA',
-						prod: 'Prod'
-					},
+			clonedExpectedConfig.package.include = ['custom/path/**'];
+			clonedExpectedConfig.package.exclude = ['something'];
+			clonedExpectedConfig.plugins = ['my-unique-plugin'];
 
-					janisDomains: {
-						local: 'janis.localhost',
-						beta: 'janisdev.in',
-						qa: 'janisqa.in',
-						prod: 'janis.in'
-					},
-
-					cacheEnabled: {
-						prod: false
-					},
-
-					customDomain: {
-						domainName: '${self:custom.serviceCode}.${param:janisDomain}',
-						basePath: 'api',
-						stage: '${self:custom.stage}',
-						createRoute53Record: true,
-						endpointType: 'regional',
-						securityPolicy: 'tls_1_2'
-					},
-
-					apiGatewayCaching: {
-						enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
-						clusterSize: '0.5',
-						ttlInSeconds: 600 // 10 minutos
-					},
-
-					'serverless-offline': {
-						httpPort: 3000,
-						lambdaPort: 23000,
-						host: '0.0.0.0',
-						stage: 'local',
-						noPrependStageInUrl: true,
-						prefix: 'api',
-						reloadHandler: true
-					},
-
-					stageVariables: {
-						serviceName: '${self:custom.serviceCode}'
-					},
-
-					reducer: {
-						ignoreMissing: true
-					},
-
-					myCustomProp: {
-						foo: 'bar'
-					}
-				},
-				anotherProp: true,
-
-				plugins: [
-					'my-unique-plugin'
-				],
-				resources: {
-					Resources: {
-
-						ServiceExecutionRole: {
-							Type: 'AWS::IAM::Role',
-							Properties: {
-								RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
-								Path: '/janis-service/',
-								AssumeRolePolicyDocument: {
-									Version: '2012-10-17',
-									Statement: [
-										{
-											Effect: 'Allow',
-											Principal: {
-												Service: [
-													'lambda.amazonaws.com'
-												]
-											},
-											Action: 'sts:AssumeRole'
-										}
-									]
-								},
-								ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
-								Policies: [
-									{
-										PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
-										PolicyDocument: {
-											Version: '2012-10-17',
-											Statement: [
-												{
-													Effect: 'Allow',
-													Action: [
-														'logs:CreateLogGroup',
-														'logs:CreateLogStream',
-														'logs:PutLogEvents'
-													],
-													Resource: [
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*'
-																]
-															]
-														},
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*:*'
-																]
-															]
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							}
-						},
-
-						UnauthorizedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'UNAUTHORIZED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '401'
-							}
-						},
-
-						BadRequestBodyResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_BODY',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						BadRequestParameters: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_PARAMETERS',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						AccessDeniedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'ACCESS_DENIED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '403'
-							}
-						},
-
-						AuthorizerConfigurationErrorResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						AuthorizerFailureResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_FAILURE',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						IntegrationTimeoutResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'INTEGRATION_TIMEOUT',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '504'
-							}
-						}
-					}
-				}
-			});
+			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
 		});
 
-		it('Should setup the Trace Layer is env vars are set', () => {
+		it('Should setup the Trace Layer if env vars are set', () => {
 
-			sinon.stub(process, 'env')
-				.value({
-					...process.env,
-					TRACE_ACCOUNT_ID: '012345678910',
-					JANIS_TRACE_EXTENSION_VERSION: '1'
-				});
+			process.env.TRACE_ACCOUNT_ID = '012345678910';
+			process.env.JANIS_TRACE_EXTENSION_VERSION = '1';
 
 			const serviceConfig = base({}, {
-				serviceCode: 'testing',
+				serviceCode: validServiceCode,
 				servicePort: validServicePort
 			});
 
-			assert.deepStrictEqual(serviceConfig, {
-				service: 'Janis${self:custom.serviceName}Service',
-				provider: {
-					name: 'aws',
-					runtime: 'nodejs18.x',
-					memorySize: 1024,
-					stage: '${opt:stage, \'local\'}',
-					region: '${opt:region, \'us-east-1\'}',
-					role: 'ServiceExecutionRole',
-					endpointType: 'REGIONAL',
-					apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
-					logRetentionInDays: 14,
-					environment: {
-						JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-						JANIS_ENV: '${self:custom.stage}',
-						MS_PATH: 'src',
-						JANIS_TRACE_EXTENSION_ENABLED: 'true'
-					},
-					tags: {
-						Owner: 'Janis',
-						Microservice: '${self:custom.serviceName}',
-						Stack: '${param:humanReadableStage}'
-					},
-					versionFunctions: false,
-					apiGateway: {
-						disableDefaultEndpoint: true,
-						minimumCompressionSize: 1024
-					},
-					logs: {
-						restApi: {
-							accessLogging: true,
-							executionLogging: false,
-							level: 'INFO',
-							fullExecutionData: false,
-							format: JSON.stringify({
-								date: '$context.requestTime',
-								reqId: '$context.requestId',
-								integReqId: '$context.integration.requestId',
-								ip: '$context.identity.sourceIp',
-								ua: '$context.identity.userAgent',
-								clientCode: '$context.authorizer.clientCode',
-								principalId: '$context.authorizer.principalId',
-								reqMethod: '$context.httpMethod',
-								path: '$context.resourcePath',
-								realPath: '$context.path',
-								status: '$context.status',
-								authTime: '$context.authorizer.latency',
-								resTime: '$context.responseLatency',
-								gwError: '$context.error.message',
-								integError: '$context.integration.error'
-							})
-						}
-					},
-					layers: [
-						'arn:aws:lambda:${aws:region}:012345678910:layer:trace:1'
-					]
-				},
-				params: {
-					local: {
-						humanReadableStage: 'Local',
-						janisDomain: 'janis.localhost'
-					},
-					beta: {
-						humanReadableStage: 'Beta',
-						janisDomain: 'janisdev.in'
-					},
-					qa: {
-						janisDomain: 'janisqa.in',
-						humanReadableStage: 'QA'
-					},
-					prod: {
-						humanReadableStage: 'Prod',
-						janisDomain: 'janis.in'
-					}
-				},
-				package: {
-					individually: false,
-					include: [
-						'src/config/*',
-						'node_modules/@babel/runtime/**'
-					],
-					exclude: [
-						'.nyc_output/**',
-						'.bitbucket/**',
-						'.deploy/**',
-						'.husky/**',
-						'view-schemas/**',
-						'view-schemas-built/**',
-						'view-schemas-built-local/**',
-						'tests/**',
-						'test-reports/**',
-						'hooks/**',
-						'events/**',
-						'permissions/**',
-						'schemas/src/**',
-						'serverless/**',
-						'src/environments/**',
-						'*',
-						'.*',
-						'node_modules/.cache/**',
-						'node_modules/**/README.md',
-						'node_modules/**/.github/**',
-						'node_modules/**/CHANGELOG.md',
-						'node_modules/**/LICENSE',
-						'node_modules/**/*.js.map',
-						'node_modules/**/*.map',
-						'node_modules/**/*.min.map',
-						'node_modules/**/*.js.flow',
-						'node_modules/**/*.d.ts',
-						'node_modules/function.prototype.name/**',
-						'node_modules/which-typed-array/**',
-						'node_modules/is-typed-array/**',
-						'mongodb/src/**',
-						'bson/dist/**',
-						'bson/src/**',
-						'node_modules/@aws-sdk/**',
-						'node_modules/**/@aws-sdk/**',
-						'node_modules/sinon/**',
-						'node_modules/serverless/**',
-						'node_modules/@serverless/**',
-						'node_modules/@babel/**',
-						'node_modules/eslint-plugin-import/**',
-						'node_modules/@sinonjs/**',
-						'node_modules/faker/dist/**',
-						'node_modules/date-fns/esm/**',
-						'node_modules/date-fns/fp/**',
-						'node_modules/**/date-fns/docs/**',
-						'node_modules/**/buffer/test/**',
-						'node_modules/**/jmespath/test/**',
-						'node_modules/**/qs/test/**',
-						'node_modules/**/qs/dist/**',
-						'node_modules/**/bson/browser_build/**',
-						'node_modules/**/axios/dist/browser/**',
-						'node_modules/**/axios/dist/esm/**'
-					]
-				},
-				custom: {
-					serviceTitle: 'Testing',
-					serviceName: 'Testing',
-					serviceCode: 'testing',
-					stage: '${self:provider.stage}',
-					region: '${self:provider.region}',
+			const clonedExpectedConfig = JSON.parse(JSON.stringify(expectedConfig));
 
-					humanReadableStage: {
-						local: 'Local',
-						beta: 'Beta',
-						qa: 'QA',
-						prod: 'Prod'
-					},
+			clonedExpectedConfig.provider.layers = ['arn:aws:lambda:${aws:region}:012345678910:layer:trace:1'];
+			clonedExpectedConfig.provider.environment.JANIS_TRACE_EXTENSION_ENABLED = 'true';
 
-					janisDomains: {
-						local: 'janis.localhost',
-						beta: 'janisdev.in',
-						qa: 'janisqa.in',
-						prod: 'janis.in'
-					},
-
-					cacheEnabled: {
-						prod: false
-					},
-
-					customDomain: {
-						domainName: '${self:custom.serviceCode}.${param:janisDomain}',
-						basePath: 'api',
-						stage: '${self:custom.stage}',
-						createRoute53Record: true,
-						endpointType: 'regional',
-						securityPolicy: 'tls_1_2'
-					},
-
-					apiGatewayCaching: {
-						enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
-						clusterSize: '0.5',
-						ttlInSeconds: 600 // 10 minutos
-					},
-
-					'serverless-offline': {
-						httpPort: 3000,
-						lambdaPort: 23000,
-						host: '0.0.0.0',
-						stage: 'local',
-						noPrependStageInUrl: true,
-						prefix: 'api',
-						reloadHandler: true
-					},
-
-					stageVariables: {
-						serviceName: '${self:custom.serviceCode}'
-					},
-
-					reducer: {
-						ignoreMissing: true
-					}
-				},
-				plugins: [
-					'serverless-domain-manager',
-					'serverless-offline',
-					'serverless-api-gateway-caching',
-					'serverless-plugin-stage-variables',
-					'@janiscommerce/serverless-plugin-remove-authorizer-permissions',
-					'serverless-plugin-split-stacks'
-				],
-				resources: {
-					Resources: {
-
-						ServiceExecutionRole: {
-							Type: 'AWS::IAM::Role',
-							Properties: {
-								RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
-								Path: '/janis-service/',
-								AssumeRolePolicyDocument: {
-									Version: '2012-10-17',
-									Statement: [
-										{
-											Effect: 'Allow',
-											Principal: {
-												Service: [
-													'lambda.amazonaws.com'
-												]
-											},
-											Action: 'sts:AssumeRole'
-										}
-									]
-								},
-								ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
-								Policies: [
-									{
-										PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
-										PolicyDocument: {
-											Version: '2012-10-17',
-											Statement: [
-												{
-													Effect: 'Allow',
-													Action: [
-														'logs:CreateLogGroup',
-														'logs:CreateLogStream',
-														'logs:PutLogEvents'
-													],
-													Resource: [
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*'
-																]
-															]
-														},
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*:*'
-																]
-															]
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							}
-						},
-
-						UnauthorizedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'UNAUTHORIZED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '401'
-							}
-						},
-
-						BadRequestBodyResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_BODY',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						BadRequestParameters: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_PARAMETERS',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						AccessDeniedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'ACCESS_DENIED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '403'
-							}
-						},
-
-						AuthorizerConfigurationErrorResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						AuthorizerFailureResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_FAILURE',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						IntegrationTimeoutResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'INTEGRATION_TIMEOUT',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '504'
-							}
-						}
-
-					}
-				}
-			});
+			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
 		});
 
 		it('Should add and override sls params if they are passed', () => {
@@ -2083,406 +604,38 @@ describe('Hooks', () => {
 					}
 				}
 			}, {
-				serviceCode: 'testing',
+				serviceCode: validServiceCode,
 				servicePort: validServicePort
 			});
 
-			assert.deepStrictEqual(serviceConfig, {
-				service: 'Janis${self:custom.serviceName}Service',
-				provider: {
-					name: 'aws',
-					runtime: 'nodejs18.x',
-					memorySize: 1024,
-					stage: '${opt:stage, \'local\'}',
-					region: '${opt:region, \'us-east-1\'}',
-					role: 'ServiceExecutionRole',
-					endpointType: 'REGIONAL',
-					apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
-					logRetentionInDays: 14,
-					environment: {
-						JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-						JANIS_ENV: '${self:custom.stage}',
-						MS_PATH: 'src',
-						JANIS_TRACE_EXTENSION_ENABLED: 'true'
-					},
-					tags: {
-						Owner: 'Janis',
-						Microservice: '${self:custom.serviceName}',
-						Stack: '${param:humanReadableStage}'
-					},
-					versionFunctions: false,
-					apiGateway: {
-						disableDefaultEndpoint: true,
-						minimumCompressionSize: 1024
-					},
-					logs: {
-						restApi: {
-							accessLogging: true,
-							executionLogging: false,
-							level: 'INFO',
-							fullExecutionData: false,
-							format: JSON.stringify({
-								date: '$context.requestTime',
-								reqId: '$context.requestId',
-								integReqId: '$context.integration.requestId',
-								ip: '$context.identity.sourceIp',
-								ua: '$context.identity.userAgent',
-								clientCode: '$context.authorizer.clientCode',
-								principalId: '$context.authorizer.principalId',
-								reqMethod: '$context.httpMethod',
-								path: '$context.resourcePath',
-								realPath: '$context.path',
-								status: '$context.status',
-								authTime: '$context.authorizer.latency',
-								resTime: '$context.responseLatency',
-								gwError: '$context.error.message',
-								integError: '$context.integration.error'
-							})
-						}
-					},
-					layers: [
-						'arn:aws:lambda:${aws:region}:012345678910:layer:trace:1'
-					]
-				},
-				params: {
-					default: {
-						defaultParam: true
-					},
-					local: {
-						humanReadableStage: 'Local',
-						janisDomain: 'janis.localhost'
-					},
-					beta: {
-						humanReadableStage: 'Super beta',
-						janisDomain: 'janisdev.in'
-					},
-					qa: {
-						janisDomain: 'janisqa.in',
-						humanReadableStage: 'Pruebas',
-						anotherParam: 'I am new'
-					},
-					prod: {
-						humanReadableStage: 'Prod',
-						janisDomain: 'janis.in'
-					}
-				},
-				package: {
-					individually: false,
-					include: [
-						'src/config/*',
-						'node_modules/@babel/runtime/**'
-					],
-					exclude: [
-						'.nyc_output/**',
-						'.bitbucket/**',
-						'.deploy/**',
-						'.husky/**',
-						'view-schemas/**',
-						'view-schemas-built/**',
-						'view-schemas-built-local/**',
-						'tests/**',
-						'test-reports/**',
-						'hooks/**',
-						'events/**',
-						'permissions/**',
-						'schemas/src/**',
-						'serverless/**',
-						'src/environments/**',
-						'*',
-						'.*',
-						'node_modules/.cache/**',
-						'node_modules/**/README.md',
-						'node_modules/**/.github/**',
-						'node_modules/**/CHANGELOG.md',
-						'node_modules/**/LICENSE',
-						'node_modules/**/*.js.map',
-						'node_modules/**/*.map',
-						'node_modules/**/*.min.map',
-						'node_modules/**/*.js.flow',
-						'node_modules/**/*.d.ts',
-						'node_modules/function.prototype.name/**',
-						'node_modules/which-typed-array/**',
-						'node_modules/is-typed-array/**',
-						'mongodb/src/**',
-						'bson/dist/**',
-						'bson/src/**',
-						'node_modules/@aws-sdk/**',
-						'node_modules/**/@aws-sdk/**',
-						'node_modules/sinon/**',
-						'node_modules/serverless/**',
-						'node_modules/@serverless/**',
-						'node_modules/@babel/**',
-						'node_modules/eslint-plugin-import/**',
-						'node_modules/@sinonjs/**',
-						'node_modules/faker/dist/**',
-						'node_modules/date-fns/esm/**',
-						'node_modules/date-fns/fp/**',
-						'node_modules/**/date-fns/docs/**',
-						'node_modules/**/buffer/test/**',
-						'node_modules/**/jmespath/test/**',
-						'node_modules/**/qs/test/**',
-						'node_modules/**/qs/dist/**',
-						'node_modules/**/bson/browser_build/**',
-						'node_modules/**/axios/dist/browser/**',
-						'node_modules/**/axios/dist/esm/**'
-					]
-				},
-				custom: {
-					serviceTitle: 'Testing',
-					serviceName: 'Testing',
-					serviceCode: 'testing',
-					stage: '${self:provider.stage}',
-					region: '${self:provider.region}',
+			const clonedExpectedConfig = JSON.parse(JSON.stringify(expectedConfig));
 
-					humanReadableStage: {
-						local: 'Local',
-						beta: 'Beta',
-						qa: 'QA',
-						prod: 'Prod'
-					},
+			clonedExpectedConfig.params.default = { defaultParam: true };
+			clonedExpectedConfig.params.beta.humanReadableStage = 'Super beta';
+			clonedExpectedConfig.params.qa.humanReadableStage = 'Pruebas';
+			clonedExpectedConfig.params.qa.anotherParam = 'I am new';
 
-					janisDomains: {
-						local: 'janis.localhost',
-						beta: 'janisdev.in',
-						qa: 'janisqa.in',
-						prod: 'janis.in'
-					},
+			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
+		});
 
-					cacheEnabled: {
-						prod: false
-					},
+		it('Should add the VPC Config when env vars LAMBDA_SECURITY_GROUP_ID and LAMBDA_SUBNET_IDS are set', () => {
 
-					customDomain: {
-						domainName: '${self:custom.serviceCode}.${param:janisDomain}',
-						basePath: 'api',
-						stage: '${self:custom.stage}',
-						createRoute53Record: true,
-						endpointType: 'regional',
-						securityPolicy: 'tls_1_2'
-					},
+			process.env.LAMBDA_SECURITY_GROUP_ID = 'sg-abcdef0001';
+			process.env.LAMBDA_SUBNET_IDS = ' subnet-111111111, subnet-222222222,subnet-333333333';
 
-					apiGatewayCaching: {
-						enabled: '${self:custom.cacheEnabled.${self:custom.stage}, \'false\'}',
-						clusterSize: '0.5',
-						ttlInSeconds: 600 // 10 minutos
-					},
-
-					'serverless-offline': {
-						httpPort: 3000,
-						lambdaPort: 23000,
-						host: '0.0.0.0',
-						stage: 'local',
-						noPrependStageInUrl: true,
-						prefix: 'api',
-						reloadHandler: true
-					},
-
-					stageVariables: {
-						serviceName: '${self:custom.serviceCode}'
-					},
-
-					reducer: {
-						ignoreMissing: true
-					}
-				},
-				plugins: [
-					'serverless-domain-manager',
-					'serverless-offline',
-					'serverless-api-gateway-caching',
-					'serverless-plugin-stage-variables',
-					'@janiscommerce/serverless-plugin-remove-authorizer-permissions',
-					'serverless-plugin-split-stacks'
-				],
-				resources: {
-					Resources: {
-
-						ServiceExecutionRole: {
-							Type: 'AWS::IAM::Role',
-							Properties: {
-								RoleName: 'Janis${self:custom.serviceName}Service-${self:custom.stage}-lambdaRole',
-								Path: '/janis-service/',
-								AssumeRolePolicyDocument: {
-									Version: '2012-10-17',
-									Statement: [
-										{
-											Effect: 'Allow',
-											Principal: {
-												Service: [
-													'lambda.amazonaws.com'
-												]
-											},
-											Action: 'sts:AssumeRole'
-										}
-									]
-								},
-								ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'],
-								Policies: [
-									{
-										PolicyName: 'janis-${self:custom.serviceCode}-logs-policy',
-										PolicyDocument: {
-											Version: '2012-10-17',
-											Statement: [
-												{
-													Effect: 'Allow',
-													Action: [
-														'logs:CreateLogGroup',
-														'logs:CreateLogStream',
-														'logs:PutLogEvents'
-													],
-													Resource: [
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*'
-																]
-															]
-														},
-														{
-															'Fn::Join': [
-																':',
-																[
-																	'arn:aws:logs',
-																	{ Ref: 'AWS::Region' },
-																	{ Ref: 'AWS::AccountId' },
-																	'log-group:/aws/lambda/*:*:*'
-																]
-															]
-														}
-													]
-												}
-											]
-										}
-									}
-								]
-							}
-						},
-
-						UnauthorizedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'UNAUTHORIZED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '401'
-							}
-						},
-
-						BadRequestBodyResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_BODY',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						BadRequestParameters: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'BAD_REQUEST_PARAMETERS',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '400'
-							}
-						},
-
-						AccessDeniedResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'ACCESS_DENIED',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '403'
-							}
-						},
-
-						AuthorizerConfigurationErrorResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_CONFIGURATION_ERROR',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						AuthorizerFailureResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":$context.error.messageString,"detail":"$context.authorizer.errorMessage","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'AUTHORIZER_FAILURE',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '500'
-							}
-						},
-
-						IntegrationTimeoutResponse: {
-							Type: 'AWS::ApiGateway::GatewayResponse',
-							Properties: {
-								ResponseParameters: {
-									'gatewayresponse.header.Access-Control-Allow-Origin': 'method.request.header.Origin'
-								},
-								ResponseTemplates: {
-									'application/json': '{"message":"Timeout","authorizerErrorType":"$context.error.responseType"}'
-								},
-								ResponseType: 'INTEGRATION_TIMEOUT',
-								RestApiId: {
-									Ref: 'ApiGatewayRestApi'
-								},
-								StatusCode: '504'
-							}
-						}
-
-					}
-				}
+			const serviceConfig = base({}, {
+				serviceCode: validServiceCode,
+				servicePort: validServicePort
 			});
+
+			const clonedExpectedConfig = JSON.parse(JSON.stringify(expectedConfig));
+
+			clonedExpectedConfig.provider.vpc = {
+				securityGroupIds: ['sg-abcdef0001'],
+				subnetIds: ['subnet-111111111', 'subnet-222222222', 'subnet-333333333']
+			};
+
+			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
 		});
 	});
 


### PR DESCRIPTION
### Modificaiones 

- Se sumó el uso de las variables de entorno `LAMBDA_SECURITY_GROUP_ID` y `LAMBDA_SUBNET_IDS` para configurar de manera "global" en un servicio, sumandolo a `provider`.
- Se modificó el test `base.js` para re-utilizar una la `expectedConfig` clonando el object.
- Se modificó el hook `janis.authorizers` para usar la variable de entorno `AUTHORIZER_ACCOUNT_ID` en vez del parámetro `accountId`

### Package
- Se sugiere llevar el package a la version `8.0.0`, ya que el package no es retro-compatible luego de las modificaciones.
- - El cambio mencionado sobre el hook `janis-authorizers` lo vuelve no-retrocompatible ya que requiere a tener la variable  `AUTHORIZER_ACCOUNT_ID` configurada para funcionar

### Dudas a futuro
- Conviene deprecar el hook `functionsVpc`? Las nuevas variables de entorno reemplazan la funcionalidad casi por completo, porque falta la creación y relación del SecurityGroup (funcionalidad que ya se realiza con Devops)