### PR TITLE
Jc 269 add function url plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,17 +234,17 @@ process.env.LAMBDA_SUBNET_IDS = 'subnet-111111111,subnet-222222222';
 
 ### Function URL
 
-Used to create Lambda functions with customized domain
+This plugin is used to create Lambda functions with customized domains. The domain structure follows the format `${customSubdomain}.${hostedZone}/{customPath}`.
 
 **Important:** 
 - This hook links **existing** Lambda functions with custom domains. It means referenced Functions must be defined before this hook.
-- If `${self:custom.customDomain.lambdaUrlDomainName` is not defined, `${self:custom.customDomain.domainName}` will be used instead.
+- The `hostedZone` name is obtained from `${self:custom.customDomain.lambdaUrlDomainName}`. If it is not defined, the value of `${self:custom.customDomain.domainName}` will be used instead.
 
 
 | Option | Type | Description |
 |--------|------|-------------|
 | subdomainName | string | Subdomain to prepend to Service domain name (defined as a custom property for each service). | |
-| acmCertificate | string | AWS's ACM Certificate Id valid for defined subdomain. Expected format `certificate/{certificateId}`| |
+| acmCertificate | string | AWS's ACM Certificate Id valid for defined subdomain.| |
 | functions | Array{} | Array of objects with path definitions for the subdomain. <br/> <br/>* ***The first referenced function will be set as the default for requests with no path.*** | |
 | functions.0.functionName | string | Name of the function being referenced. <br/> <br/> * ***In order to be valid, referenced Functions must be defined as Lambdas Url***.                                                  |
 | functions.0.path | string | Relative path associated with the function. <br/> <br/> * ***Use '*' to redirect all requests with that specific path and any additional subpaths to that specific function***                                                                      |
@@ -257,7 +257,7 @@ It will automatically create (or update) a Cloudfront Distribution and a Route 5
 	"janis.functionUrl",
 	{
 		"subdomainName": "subSubdomain.subdomain",
-		"acmCertificate": "certificate/${param:acmCertificateId}",
+		"acmCertificate": "${param:acmCertificateId}",
 		"functions": [
 			{
 				"functionName": "CustomUrlLambda",
@@ -271,10 +271,10 @@ It will automatically create (or update) a Cloudfront Distribution and a Route 5
 	}
 ]
 ```
->Expected URLs to access CustomUrlLambda: `https://subSubdomain.subdomain.{HostedZoneName}/customUrl`.
+> Expected URLs to access CustomUrlLambda: `https://subSubdomain.subdomain.{HostedZoneName}/customUrl`.
 `https://subSubdomain.subdomain.{HostedZoneName}/customUrl/subpath`
 
-> Expected URL to access CustomUrlLambda: `https://subSubdomain.subdomain.{HostedZoneName}/customUrl`
+> Expected URL to access CustomUrlLambda2: `https://subSubdomain.subdomain.{HostedZoneName}/customUrl2`
 ## Full example
 
 ```js
@@ -375,17 +375,15 @@ module.exports = helper({
 		}],
 
 		['janis.functionUrl', {
-		subdomainName: 'subSubdomain.subdomain',
-		acmCertificate: 'certificate/${param:acmCertificateId}',
-		functions: [
-			{
-				functionName: 'CustomUrlLambda',
-				path: '/customUrl/*'
-			}
-		]
-	}
-]
-
+			subdomainName: 'subSubdomain.subdomain',
+			acmCertificate: '${param:acmCertificateId}',
+			functions: [
+				{
+					functionName: 'CustomUrlLambda',
+					path: '/customUrl/*'
+				}
+			]
+		}]
 	]
 }, {});
 ```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,49 @@ process.env.LAMBDA_SECURITY_GROUP_ID = 'sg-abcdef0001';
 process.env.LAMBDA_SUBNET_IDS = 'subnet-111111111,subnet-222222222';
 ```
 
+### Function URL
+
+Used to create Lambda functions with customized domain
+
+**Important:** 
+- This hook links **existing** Lambda functions with custom domains. It means referenced Functions must be defined before this hook.
+- If `${self:custom.customDomain.lambdaUrlDomainName` is not defined, `${self:custom.customDomain.domainName}` will be used instead.
+
+
+| Option | Type | Description |
+|--------|------|-------------|
+| subdomainName | string | Subdomain to prepend to Service domain name (defined as a custom property for each service). | |
+| acmCertificate | string | AWS's ACM Certificate Id valid for defined subdomain. Expected format `certificate/{certificateId}`| |
+| functions | Array{} | Array of objects with path definitions for the subdomain. <br/> <br/>* ***The first referenced function will be set as the default for requests with no path.*** | |
+| functions.0.functionName | string | Name of the function being referenced. <br/> <br/> * ***In order to be valid, referenced Functions must be defined as Lambdas Url***.                                                  |
+| functions.0.path | string | Relative path associated with the function. <br/> <br/> * ***Use '*' to redirect all requests with that specific path and any additional subpaths to that specific function***                                                                      |
+
+It will automatically create (or update) a Cloudfront Distribution and a Route 53 Record Set.
+
+
+```js
+[
+	"janis.functionUrl",
+	{
+		"subdomainName": "subSubdomain.subdomain",
+		"acmCertificate": "certificate/${param:acmCertificateId}",
+		"functions": [
+			{
+				"functionName": "CustomUrlLambda",
+				"path": "/customUrl/*"
+			},
+			{
+				"functionName": "CustomUrlLambda2",
+				"path": "/customUrl2/"
+			}
+		]
+	}
+]
+```
+>Expected URLs to access CustomUrlLambda: `https://subSubdomain.subdomain.{HostedZoneName}/customUrl`.
+`https://subSubdomain.subdomain.{HostedZoneName}/customUrl/subpath`
+
+> Expected URL to access CustomUrlLambda: `https://subSubdomain.subdomain.{HostedZoneName}/customUrl`
 ## Full example
 
 ```js
@@ -329,7 +372,19 @@ module.exports = helper({
 				'subnet-111111111',
 				'subnet-222222222'
 			]
-		}]
+		}],
+
+		['janis.functionUrl', {
+		subdomainName: 'subSubdomain.subdomain',
+		acmCertificate: 'certificate/${param:acmCertificateId}',
+		functions: [
+			{
+				functionName: 'CustomUrlLambda',
+				path: '/customUrl/*'
+			}
+		]
+	}
+]
 
 	]
 }, {});

--- a/lib/function-url/base.js
+++ b/lib/function-url/base.js
@@ -1,31 +1,33 @@
-const { getCloudFrontDistribution } = require('../function-url/distribution');
-const { getFormattedRouter } = require('../function-url/route-53');
+'use strict';
+
+const { getCloudFrontDistribution } = require('./distribution');
+const { getFormattedRouter } = require('./route-53');
 
 const getUniqueFunctions = ({ functions: hookFunctions, rawSubdomainName }) => {
 
-	return hookFunctions.reduce((uniqueFunctions, functionData, index ) => {
-			
+	return hookFunctions.reduce((uniqueFunctions, functionData, index) => {
+
 		if(!functionData.functionName)
 			throw new Error(`Missing function name for ${rawSubdomainName}.functions[${index}]`);
 
 		if(!functionData.path)
 			throw new Error(`Missing path for ${rawSubdomainName}.${functionData.functionName} function`);
-	
+
 		uniqueFunctions[functionData.functionName] = functionData;
 
 		return uniqueFunctions;
-	}, {})
-}
+	}, {});
+};
 
 module.exports.formatResources = (resources, hookParams) => {
 
 	if(!hookParams.subdomainName)
-		throw new Error(`Missing subdomainName in function url definition`);
+		throw new Error('Missing subdomainName in function url definition');
 
 	if(!hookParams.acmCertificate)
 		throw new Error(`Missing acmCertificate for ${hookParams.rawSubdomainName} subdomain`);
 
-	hookParams.functions = getUniqueFunctions(hookParams)
+	hookParams.functions = getUniqueFunctions(hookParams);
 
 	const { name: distributionName, distribution } = getCloudFrontDistribution(resources, hookParams);
 
@@ -33,18 +35,18 @@ module.exports.formatResources = (resources, hookParams) => {
 
 	const currentResources = (resources && resources.Resources) || {};
 
-	if(Array.isArray(currentResources)){
-		
-		const distributionIndex = currentResources.findIndex(resource => !!resource[distributionName])
+	if(Array.isArray(currentResources)) {
+
+		const distributionIndex = currentResources.findIndex(resource => !!resource[distributionName]);
 
 		if(distributionIndex >= 0)
-			currentResources[distributionIndex][distributionName] = distribution
+			currentResources[distributionIndex][distributionName] = distribution;
 
 		return [
 			...currentResources,
 			...(routerConfig ? [{ [routerName]: routerConfig }] : []),
 			...(distributionIndex < 0) ? [{ [distributionName]: distribution }] : []
-		]
+		];
 	}
 
 	return {

--- a/lib/function-url/base.js
+++ b/lib/function-url/base.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { getCloudFrontDistribution } = require('./distribution');
-const { getFormattedRouter } = require('./route-53');
+const { getFormattedRecordSet } = require('./route-53');
 
 const getUniqueFunctions = ({ functions: hookFunctions, rawSubdomainName }) => {
 
@@ -31,7 +31,7 @@ module.exports.formatResources = (resources, hookParams) => {
 
 	const { name: distributionName, distribution } = getCloudFrontDistribution(resources, hookParams);
 
-	const { name: routerName, routerConfig } = getFormattedRouter(resources, hookParams);
+	const { name: routerName, routerConfig } = getFormattedRecordSet(resources, hookParams);
 
 	const currentResources = (resources && resources.Resources) || {};
 

--- a/lib/function-url/base.js
+++ b/lib/function-url/base.js
@@ -1,0 +1,55 @@
+const { getCloudFrontDistribution } = require('../function-url/distribution');
+const { getFormattedRouter } = require('../function-url/route-53');
+
+const getUniqueFunctions = ({ functions: hookFunctions, rawSubdomainName }) => {
+
+	return hookFunctions.reduce((uniqueFunctions, functionData, index ) => {
+			
+		if(!functionData.functionName)
+			throw new Error(`Missing function name for ${rawSubdomainName}.functions[${index}]`);
+
+		if(!functionData.path)
+			throw new Error(`Missing path for ${rawSubdomainName}.${functionData.functionName} function`);
+	
+		uniqueFunctions[functionData.functionName] = functionData;
+
+		return uniqueFunctions;
+	}, {})
+}
+
+module.exports.formatResources = (resources, hookParams) => {
+
+	if(!hookParams.subdomainName)
+		throw new Error(`Missing subdomainName in function url definition`);
+
+	if(!hookParams.acmCertificate)
+		throw new Error(`Missing acmCertificate for ${hookParams.rawSubdomainName} subdomain`);
+
+	hookParams.functions = getUniqueFunctions(hookParams)
+
+	const { name: distributionName, distribution } = getCloudFrontDistribution(resources, hookParams);
+
+	const { name: routerName, routerConfig } = getFormattedRouter(resources, hookParams);
+
+	const currentResources = (resources && resources.Resources) || {};
+
+	if(Array.isArray(currentResources)){
+		
+		const distributionIndex = currentResources.findIndex(resource => !!resource[distributionName])
+
+		if(distributionIndex >= 0)
+			currentResources[distributionIndex][distributionName] = distribution
+
+		return [
+			...currentResources,
+			...(routerConfig ? [{ [routerName]: routerConfig }] : []),
+			...(distributionIndex < 0) ? [{ [distributionName]: distribution }] : []
+		]
+	}
+
+	return {
+		...currentResources,
+		...routerConfig && { [routerName]: routerConfig },
+		[distributionName]: distribution
+	};
+};

--- a/lib/function-url/base.js
+++ b/lib/function-url/base.js
@@ -44,7 +44,7 @@ module.exports.formatResources = (resources, hookParams) => {
 
 		return [
 			...currentResources,
-			...(routerConfig ? [{ [routerName]: routerConfig }] : []),
+			...routerConfig ? [{ [routerName]: routerConfig }] : [],
 			...(distributionIndex < 0) ? [{ [distributionName]: distribution }] : []
 		];
 	}
@@ -55,3 +55,5 @@ module.exports.formatResources = (resources, hookParams) => {
 		[distributionName]: distribution
 	};
 };
+
+module.exports.hostedZone = '${self:custom.customDomain.lambdaUrlDomainName, self:custom.customDomain.domainName}';

--- a/lib/function-url/distribution.js
+++ b/lib/function-url/distribution.js
@@ -39,9 +39,9 @@ const getCurrentDistribution = (resources, { subdomainName }) => {
 	return resources.Resources[resourceName];
 };
 
-const getBaseDistribution = ({ subdomainName, acmCertificate, rawSubdomainName }) => {
+const getBaseDistribution = ({ hostedZone, subdomainName, acmCertificate, rawSubdomainName }) => {
 
-	const alias = rawSubdomainName + '.${self:custom.customDomain.domainName}';
+	const alias = `${rawSubdomainName}.${hostedZone}`;
 
 	return {
 

--- a/lib/function-url/distribution.js
+++ b/lib/function-url/distribution.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const defaultCache = {
+	ViewerProtocolPolicy: 'redirect-to-https',
+	Compress: true,
+	DefaultTTL: 0,
+	AllowedMethods: ['HEAD', 'DELETE', 'POST', 'GET', 'OPTIONS', 'PUT', 'PATCH'],
+	CachedMethods: ['GET', 'HEAD'],
+	ForwardedValues: {
+		QueryString: false,
+		Headers: ['Accept', 'x-api-key', 'Authorization'],
+		Cookies: {
+			Forward: 'none'
+		}
+	}
+};
+
+const CustomOriginConfig = {
+	HTTPPort: 80,
+	HTTPSPort: 443,
+	OriginProtocolPolicy: 'https-only',
+	OriginSSLProtocols: ['TLSv1', 'TLSv1.1', 'TLSv1.2']
+};
+
+const getCurrentDistribution = (resources, { subdomainName }) => {
+
+	if(!resources || !resources.Resources)
+		return;
+
+	const resourceName = [`${subdomainName}CloudFrontDistribution`];
+
+	if(Array.isArray(resources.Resources)){
+
+		const distribution = resources.Resources.find(resource => resource[resourceName]);
+		
+		return distribution && distribution[resourceName] 
+	}
+	
+	return resources.Resources[resourceName]
+}
+
+const getBaseDistribution = ({ subdomainName, acmCertificate, rawSubdomainName }) => {
+	
+	const alias = rawSubdomainName + '.${self:custom.customDomain.domainName}'
+
+	return {
+
+		name: `${subdomainName}CloudFrontDistribution`,
+		resource: {
+			Type: 'AWS::CloudFront::Distribution',
+			Properties: {
+				DistributionConfig: {
+					Enabled: true,
+					PriceClass: 'PriceClass_100',
+					HttpVersion: 'http2',
+					Comment: alias,
+					Origins: [],
+					CacheBehaviors: [],
+					Aliases: [
+						alias
+					],
+					ViewerCertificate: {
+						SslSupportMethod: 'sni-only',
+						MinimumProtocolVersion: 'TLSv1.2_2019',
+						AcmCertificateArn: {
+							'Fn::Join': [
+								':',
+								[
+									'arn:aws:acm',
+									'${self:custom.region}',
+									{ Ref: 'AWS::AccountId' },
+									acmCertificate
+								]
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+};
+
+const formatOrigin = ({ functionName }) => ({
+	DomainName: {
+		'Fn::Select': [
+			2,
+			{
+				'Fn::Split': [
+					'/',
+					{
+						'Fn::GetAtt': [
+							`${functionName}LambdaFunctionUrl`,
+							'FunctionUrl'
+						]
+					}
+				]
+			}
+		]
+	},
+	Id: functionName,
+	OriginPath: '',
+	CustomOriginConfig
+})
+
+const formatCacheBehavior = ({ functionName, path }) => ({
+	TargetOriginId: functionName,
+	...defaultCache,
+	PathPattern: path
+})
+
+module.exports.getCloudFrontDistribution = (resources, hookParams) => {
+
+	const baseDistribution = getBaseDistribution(hookParams);
+
+	const distribution = getCurrentDistribution(resources, hookParams) || baseDistribution.resource;
+
+	const { Origins: currentOrigins } = { ...distribution.Properties.DistributionConfig }
+
+	const functions = Object.values(hookParams.functions);
+
+	functions.forEach(functionConfig => {
+
+		if (!currentOrigins.some(({ Id }) => functionConfig.functionName === Id)) {
+	
+			distribution.Properties.DistributionConfig.Origins.push(formatOrigin(functionConfig))
+			distribution.Properties.DistributionConfig.CacheBehaviors.push(formatCacheBehavior(functionConfig))
+		}
+	})
+
+	if(!distribution.Properties.DistributionConfig.DefaultCacheBehavior) {
+
+		distribution.Properties.DistributionConfig.DefaultCacheBehavior = {
+			...defaultCache,
+			TargetOriginId: functions[0].functionName // hasta encontrar como bloquearlo
+		}
+	}
+
+	return { name: baseDistribution.name, distribution };
+}

--- a/lib/function-url/distribution.js
+++ b/lib/function-url/distribution.js
@@ -29,19 +29,19 @@ const getCurrentDistribution = (resources, { subdomainName }) => {
 
 	const resourceName = [`${subdomainName}CloudFrontDistribution`];
 
-	if(Array.isArray(resources.Resources)){
+	if(Array.isArray(resources.Resources)) {
 
 		const distribution = resources.Resources.find(resource => resource[resourceName]);
-		
-		return distribution && distribution[resourceName] 
+
+		return distribution && distribution[resourceName];
 	}
-	
-	return resources.Resources[resourceName]
-}
+
+	return resources.Resources[resourceName];
+};
 
 const getBaseDistribution = ({ subdomainName, acmCertificate, rawSubdomainName }) => {
-	
-	const alias = rawSubdomainName + '.${self:custom.customDomain.domainName}'
+
+	const alias = rawSubdomainName + '.${self:custom.customDomain.domainName}';
 
 	return {
 
@@ -77,7 +77,7 @@ const getBaseDistribution = ({ subdomainName, acmCertificate, rawSubdomainName }
 				}
 			}
 		}
-	}
+	};
 };
 
 const formatOrigin = ({ functionName }) => ({
@@ -100,13 +100,13 @@ const formatOrigin = ({ functionName }) => ({
 	Id: functionName,
 	OriginPath: '',
 	CustomOriginConfig
-})
+});
 
 const formatCacheBehavior = ({ functionName, path }) => ({
 	TargetOriginId: functionName,
 	...defaultCache,
 	PathPattern: path
-})
+});
 
 module.exports.getCloudFrontDistribution = (resources, hookParams) => {
 
@@ -114,26 +114,26 @@ module.exports.getCloudFrontDistribution = (resources, hookParams) => {
 
 	const distribution = getCurrentDistribution(resources, hookParams) || baseDistribution.resource;
 
-	const { Origins: currentOrigins } = { ...distribution.Properties.DistributionConfig }
+	const { Origins: currentOrigins } = { ...distribution.Properties.DistributionConfig };
 
 	const functions = Object.values(hookParams.functions);
 
 	functions.forEach(functionConfig => {
 
-		if (!currentOrigins.some(({ Id }) => functionConfig.functionName === Id)) {
-	
-			distribution.Properties.DistributionConfig.Origins.push(formatOrigin(functionConfig))
-			distribution.Properties.DistributionConfig.CacheBehaviors.push(formatCacheBehavior(functionConfig))
+		if(!currentOrigins.some(({ Id }) => functionConfig.functionName === Id)) {
+
+			distribution.Properties.DistributionConfig.Origins.push(formatOrigin(functionConfig));
+			distribution.Properties.DistributionConfig.CacheBehaviors.push(formatCacheBehavior(functionConfig));
 		}
-	})
+	});
 
 	if(!distribution.Properties.DistributionConfig.DefaultCacheBehavior) {
 
 		distribution.Properties.DistributionConfig.DefaultCacheBehavior = {
 			...defaultCache,
 			TargetOriginId: functions[0].functionName // hasta encontrar como bloquearlo
-		}
+		};
 	}
 
 	return { name: baseDistribution.name, distribution };
-}
+};

--- a/lib/function-url/distribution.js
+++ b/lib/function-url/distribution.js
@@ -69,7 +69,7 @@ const getBaseDistribution = ({ hostedZone, subdomainName, acmCertificate, rawSub
 									'arn:aws:acm',
 									'${self:custom.region}',
 									{ Ref: 'AWS::AccountId' },
-									acmCertificate
+									`certificate/${acmCertificate}`
 								]
 							]
 						}
@@ -114,7 +114,7 @@ module.exports.getCloudFrontDistribution = (resources, hookParams) => {
 
 	const distribution = getCurrentDistribution(resources, hookParams) || baseDistribution.resource;
 
-	const { Origins: currentOrigins } = { ...distribution.Properties.DistributionConfig };
+	const { Origins: currentOrigins } = distribution.Properties.DistributionConfig;
 
 	const functions = Object.values(hookParams.functions);
 

--- a/lib/function-url/index.js
+++ b/lib/function-url/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const upperCamelCase = require('../utils/upperCamelCase');
-const { formatResources } = require('./base');
+const { formatResources, hostedZone } = require('./base');
 
 module.exports = ({ resources, ...serviceConfig }, { subdomainName, ...hookParams }) => {
 
@@ -10,6 +10,7 @@ module.exports = ({ resources, ...serviceConfig }, { subdomainName, ...hookParam
 		resources: {
 			Resources: formatResources(resources, {
 				...hookParams,
+				hostedZone,
 				rawSubdomainName: subdomainName,
 				subdomainName: upperCamelCase(subdomainName)
 			})

--- a/lib/function-url/index.js
+++ b/lib/function-url/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const upperCamelCase = require('../utils/upperCamelCase');
+const { formatResources } = require('./base');
+
+module.exports = ({ resources, ...serviceConfig }, { subdomainName, ...hookParams }) => {
+
+	return {
+		...serviceConfig,
+		resources: {
+			Resources: formatResources(resources, {
+				...hookParams,
+				rawSubdomainName: subdomainName,
+				subdomainName: upperCamelCase(subdomainName)
+			})
+		}
+	};
+};

--- a/lib/function-url/route-53.js
+++ b/lib/function-url/route-53.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * @param {Array|Object} resources
+ * @param {String} subdomainName
+ * @returns {Boolean} True if resource was not already created
+*/
 const shouldCreateRouter = (resources, subdomainName) => {
 
 	if(!resources || !resources.Resources)
@@ -9,7 +14,7 @@ const shouldCreateRouter = (resources, subdomainName) => {
 
 	return Array.isArray(resources.Resources) ?
 		!resources.Resources.find(resource => resource[resourceName]) :
-		resources.Resources[resourceName];
+		!resources.Resources[resourceName];
 };
 
 const getNewRoute = (subdomainName, rawSubdomainName) => {

--- a/lib/function-url/route-53.js
+++ b/lib/function-url/route-53.js
@@ -40,7 +40,7 @@ const getNewRoute = (hostedZone, subdomainName, rawSubdomainName) => {
 	};
 };
 
-module.exports.getFormattedRouter = (resources, { hostedZone, subdomainName, rawSubdomainName }) => {
+module.exports.getFormattedRecordSet = (resources, { hostedZone, subdomainName, rawSubdomainName }) => {
 
 	if(!shouldCreateRouter(resources, subdomainName))
 		return {};

--- a/lib/function-url/route-53.js
+++ b/lib/function-url/route-53.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const shouldCreateRouter = (resources, subdomainName) => {
+
+	if(!resources || !resources.Resources)
+		return true;
+
+	const resourceName = [`${subdomainName}RecordSet`];
+
+	return Array.isArray(resources.Resources) ?
+		!resources.Resources.find(resource => resource[resourceName]) :
+		resources.Resources[resourceName];
+};
+
+const getNewRoute = (subdomainName, rawSubdomainName) => {
+
+	const Name = rawSubdomainName + '.${self:custom.customDomain.domainName}';
+
+	return {
+		name: `${subdomainName}RecordSet`,
+		routerConfig: {
+			Type: 'AWS::Route53::RecordSet',
+			Properties: {
+				HostedZoneName: '${self:custom.customDomain.domainName}.',
+				Type: 'A',
+				Name,
+				AliasTarget: {
+					HostedZoneId: 'Z2FDTNDATAQYW2', // CloudFront zone ID
+					DNSName: {
+						'Fn::GetAtt': `${subdomainName}CloudFrontDistribution.DomainName`
+					}
+				}
+			}
+		}
+	};
+};
+
+module.exports.getFormattedRouter = (resources, { subdomainName, rawSubdomainName }) => {
+
+	if(!shouldCreateRouter(resources, subdomainName))
+		return {};
+
+	return getNewRoute(subdomainName, rawSubdomainName);
+};

--- a/lib/function-url/route-53.js
+++ b/lib/function-url/route-53.js
@@ -17,16 +17,16 @@ const shouldCreateRouter = (resources, subdomainName) => {
 		!resources.Resources[resourceName];
 };
 
-const getNewRoute = (subdomainName, rawSubdomainName) => {
+const getNewRoute = (hostedZone, subdomainName, rawSubdomainName) => {
 
-	const Name = rawSubdomainName + '.${self:custom.customDomain.domainName}';
+	const Name = `${rawSubdomainName}.${hostedZone}`;
 
 	return {
 		name: `${subdomainName}RecordSet`,
 		routerConfig: {
 			Type: 'AWS::Route53::RecordSet',
 			Properties: {
-				HostedZoneName: '${self:custom.customDomain.domainName}.',
+				HostedZoneName: `${hostedZone}.`,
 				Type: 'A',
 				Name,
 				AliasTarget: {
@@ -40,10 +40,10 @@ const getNewRoute = (subdomainName, rawSubdomainName) => {
 	};
 };
 
-module.exports.getFormattedRouter = (resources, { subdomainName, rawSubdomainName }) => {
+module.exports.getFormattedRouter = (resources, { hostedZone, subdomainName, rawSubdomainName }) => {
 
 	if(!shouldCreateRouter(resources, subdomainName))
 		return {};
 
-	return getNewRoute(subdomainName, rawSubdomainName);
+	return getNewRoute(hostedZone, subdomainName, rawSubdomainName);
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -25,3 +25,5 @@ module.exports.functionsVpc = require('./functions-vpc');
 module.exports.dbConfig = require('./secrets/database-config');
 
 module.exports.stateMachine = require('./state-machine');
+
+module.exports.functionUrl = require('./function-url');

--- a/lib/utils/upperCamelCase.js
+++ b/lib/utils/upperCamelCase.js
@@ -3,4 +3,5 @@
 const toCamelCase = require('lodash.camelcase');
 const startCase = require('lodash.startcase');
 
-module.exports = str => startCase(toCamelCase(str)).split(' ').join('')
+module.exports = str => startCase(toCamelCase(str)).split(' ')
+	.join('');

--- a/lib/utils/upperCamelCase.js
+++ b/lib/utils/upperCamelCase.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const toCamelCase = require('lodash.camelcase');
+const startCase = require('lodash.startcase');
+
+module.exports = str => startCase(toCamelCase(str)).split(' ').join('')

--- a/tests/unit/hooks/function-url.js
+++ b/tests/unit/hooks/function-url.js
@@ -1,0 +1,319 @@
+'use strict';
+
+const assert = require('assert').strict;
+
+const { functionUrl } = require('../../../lib/plugin');
+
+describe('Hooks', () => {
+
+	describe('Function Url', () => {
+
+		const functionDefinition = {
+			functionName: 'LambdaUrlTest',
+			path: '/LambdaUrlTest'
+		};
+
+		const functionUrlConfig = {
+			subdomainName: 'lambda_url',
+			acmCertificate: '123456789',
+			functions: [functionDefinition]
+		}
+
+		const resourcesName = 'lambda_url.${self:custom.customDomain.domainName}'
+
+		const getSampleOrigin = (functionName = functionDefinition.functionName) => ({
+			DomainName: {
+				'Fn::Select': [
+					2,
+					{
+						'Fn::Split': [
+							'/',
+							{
+								'Fn::GetAtt': [
+									`${functionName}LambdaFunctionUrl`,
+									'FunctionUrl'
+								]
+							}
+						]
+					}
+				]
+			},
+			Id: functionName,
+			OriginPath: '',
+			CustomOriginConfig: {
+				HTTPPort: 80,
+				HTTPSPort: 443,
+				OriginProtocolPolicy: 'https-only',
+				OriginSSLProtocols: ['TLSv1', 'TLSv1.1', 'TLSv1.2']
+			}
+		});
+
+		const defaultCache = {
+			ViewerProtocolPolicy: 'redirect-to-https',
+			Compress: true,
+			DefaultTTL: 0,
+			AllowedMethods: ['HEAD', 'DELETE', 'POST', 'GET', 'OPTIONS', 'PUT', 'PATCH'],
+			CachedMethods: ['GET', 'HEAD'],
+			ForwardedValues: {
+				QueryString: false,
+				Headers: ['Accept', 'x-api-key', 'Authorization'],
+				Cookies: {
+					Forward: 'none'
+				}
+			}
+		};
+
+		const sampleCacheBehavior = {
+			...defaultCache,
+			TargetOriginId: functionDefinition.functionName,
+			PathPattern: functionDefinition.path
+		}
+
+		const sampleDistribution = {
+			Type: 'AWS::CloudFront::Distribution',
+			Properties: {
+				DistributionConfig: {
+					Enabled: true,
+					PriceClass: 'PriceClass_100',
+					HttpVersion: 'http2',
+					Comment: resourcesName,
+					Origins: [getSampleOrigin()],
+					CacheBehaviors: [sampleCacheBehavior],
+					DefaultCacheBehavior: {
+						...defaultCache,
+						TargetOriginId: functionDefinition.functionName
+					},
+					Aliases: [
+						resourcesName
+					],
+					ViewerCertificate: {
+						SslSupportMethod: 'sni-only',
+						MinimumProtocolVersion: 'TLSv1.2_2019',
+						AcmCertificateArn: {
+							'Fn::Join': [
+								':',
+								[
+									'arn:aws:acm',
+									'${self:custom.region}',
+									{ Ref: 'AWS::AccountId' },
+									functionUrlConfig.acmCertificate
+								]
+							]
+						}
+					}
+				}
+			}
+		};
+
+		const sampleRouterRecordSet = {
+			Type: 'AWS::Route53::RecordSet',
+			Properties: {
+				HostedZoneName: '${self:custom.customDomain.domainName}.',
+				Type: 'A',
+				Name: resourcesName,
+				AliasTarget: {
+					HostedZoneId: 'Z2FDTNDATAQYW2', // CloudFront zone ID
+					DNSName: {
+						'Fn::GetAtt': 'LambdaUrlCloudFrontDistribution.DomainName'
+					}
+				}
+			}
+		}
+
+		context('Config validation', () => {
+
+			it('Should throw if any function path param is missing', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					functions: [{ ...functionDefinition, path: undefined }]
+				}), {
+					message: `Missing path for ${functionUrlConfig.subdomainName}.${functionDefinition.functionName} function`
+				});
+			});
+
+			it('Should throw if domain param is passed as empty', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					functions: [{ ...functionDefinition, path: '' }]
+				}), {
+					message: `Missing path for ${functionUrlConfig.subdomainName}.${functionDefinition.functionName} function`
+				});
+			});
+
+			it('Should throw if any functionName is missing', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					functions: [{ ...functionDefinition, functionName: undefined }]
+				}), {
+					message: `Missing function name for ${functionUrlConfig.subdomainName}.functions[0]`
+				});
+			});
+
+			it('Should throw if any functionName is passed as empty', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					functions: [{ ...functionDefinition, functionName: '' }]
+				}), {
+					message: `Missing function name for ${functionUrlConfig.subdomainName}.functions[0]`
+				});
+			});
+
+			it('Should throw if subdomain is missing', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					subdomainName: undefined
+				}), {
+					message: 'Missing subdomainName in function url definition'
+				});
+			});
+
+			it('Should throw if subdomain is passed as empty', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					subdomainName: ''
+				}), {
+					message: 'Missing subdomainName in function url definition'
+				});
+			});
+
+			it('Should throw if acmCertificate is missing', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					acmCertificate: undefined
+				}), {
+					message: `Missing acmCertificate for ${functionUrlConfig.subdomainName} subdomain`
+				});
+			});
+
+			it('Should throw if acmCertificate is passed as empty', () => {
+
+				assert.throws(() => functionUrl({}, {
+					...functionUrlConfig,
+					acmCertificate: ''
+				}), {
+					message: `Missing acmCertificate for ${functionUrlConfig.subdomainName} subdomain`
+				});
+			});
+		});
+
+		context('CloudFront Distribution', () => {
+
+			it('Should create a CloudFront Distribution', () => {
+
+				const result = functionUrl({
+					resources: {
+						Resources: [{ LambdaUrlRecordSet: sampleRouterRecordSet }]
+					}
+				}, functionUrlConfig);
+
+				console.log(result.resources.Resources[1])
+				
+				assert.deepStrictEqual(result.resources.Resources[1].LambdaUrlCloudFrontDistribution, sampleDistribution);
+			});
+
+			it('Should add origin to existing distribution', () => {
+
+				const result = functionUrl({ resources: { Resources: { LambdaUrlCloudFrontDistribution: sampleDistribution } } }, {
+					...functionUrlConfig,
+					functions: [{
+						functionName: 'LambdaUrlTest2',
+						path: '/LambdaUrlTest2'
+					}]
+				});
+
+				assert.deepStrictEqual(result.resources.Resources.LambdaUrlCloudFrontDistribution, {
+					...sampleDistribution,
+					Properties: {
+						DistributionConfig: {
+							...sampleDistribution.Properties.DistributionConfig,
+							Origins: [getSampleOrigin(), getSampleOrigin('LambdaUrlTest2')],
+							CacheBehaviors: [
+								sampleCacheBehavior,
+								{
+									...defaultCache,
+									TargetOriginId: 'LambdaUrlTest2',
+									PathPattern: '/LambdaUrlTest2'
+								}
+							]
+						}
+
+					}
+				});
+			});
+
+			it('Should not add origin if it already exists', () => {
+
+				const result = functionUrl({ resources: { Resources: { LambdaUrlCloudFrontDistribution: sampleDistribution } } }, functionUrlConfig);
+
+				assert.deepStrictEqual(result.resources.Resources.LambdaUrlCloudFrontDistribution, sampleDistribution);
+			});
+		})
+
+		context('Route53 record set', () => {
+
+			it('Should create a new Route53 Record Set', () => {
+
+				const result = functionUrl({}, functionUrlConfig);
+
+				assert.deepStrictEqual(result.resources.Resources.LambdaUrlRecordSet, sampleRouterRecordSet);
+			});
+
+			it('Should add new Route53 Record Set to resources array', () => {
+
+				const result = functionUrl({
+					resources: {
+						Resources: [{ LambdaUrl2RecordSet: sampleRouterRecordSet }]
+					}
+				}, functionUrlConfig);
+
+				assert.deepStrictEqual(result.resources.Resources[1].LambdaUrlRecordSet, sampleRouterRecordSet);
+			});
+
+			it('Should not create a new Route53 Record Set', () => {
+
+				const result = functionUrl({
+					resources: {
+						Resources: [{ LambdaUrlCloudFrontDistribution: sampleDistribution }, { LambdaUrlRecordSet: sampleRouterRecordSet }]
+					}
+				}, {
+						...functionUrlConfig,
+						functions: [{
+							functionName: 'LambdaUrlTest2',
+							path: '/LambdaUrlTest2'
+						}]
+				});
+
+				assert.deepStrictEqual(result.resources.Resources, [
+					{
+						LambdaUrlCloudFrontDistribution: {
+							...sampleDistribution,
+							Properties: {
+								DistributionConfig: {
+									...sampleDistribution.Properties.DistributionConfig,
+									Origins: [getSampleOrigin(), getSampleOrigin('LambdaUrlTest2')],
+									CacheBehaviors: [
+										sampleCacheBehavior,
+										{
+											...defaultCache,
+											TargetOriginId: 'LambdaUrlTest2',
+											PathPattern: '/LambdaUrlTest2'
+										}
+									]
+								}
+
+							}
+						}
+					},
+					{ LambdaUrlRecordSet: sampleRouterRecordSet }
+				]);
+			});
+		})
+	});
+});

--- a/tests/unit/hooks/function-url.js
+++ b/tests/unit/hooks/function-url.js
@@ -205,7 +205,7 @@ describe('Hooks', () => {
 
 		context('CloudFront Distribution', () => {
 
-			it('Should create a CloudFront Distribution', () => {
+			it('Should create a CloudFront Distribution if it does not already exist in resources Array', () => {
 
 				const result = functionUrl({
 					resources: {
@@ -214,6 +214,17 @@ describe('Hooks', () => {
 				}, functionUrlConfig);
 
 				assert.deepStrictEqual(result.resources.Resources[1].LambdaUrlCloudFrontDistribution, sampleDistribution);
+			});
+
+			it('Should create a CloudFront Distribution if it does not already exist in resources Object', () => {
+
+				const result = functionUrl({
+					resources: {
+						Resources: { LambdaUrlRecordSet: sampleRouterRecordSet }
+					}
+				}, functionUrlConfig);
+
+				assert.deepStrictEqual(result.resources.Resources.LambdaUrlCloudFrontDistribution, sampleDistribution);
 			});
 
 			it('Should add origin to existing distribution', () => {

--- a/tests/unit/hooks/function-url.js
+++ b/tests/unit/hooks/function-url.js
@@ -17,9 +17,9 @@ describe('Hooks', () => {
 			subdomainName: 'lambda_url',
 			acmCertificate: '123456789',
 			functions: [functionDefinition]
-		}
+		};
 
-		const resourcesName = 'lambda_url.${self:custom.customDomain.domainName}'
+		const resourcesName = 'lambda_url.${self:custom.customDomain.domainName}';
 
 		const getSampleOrigin = (functionName = functionDefinition.functionName) => ({
 			DomainName: {
@@ -67,7 +67,7 @@ describe('Hooks', () => {
 			...defaultCache,
 			TargetOriginId: functionDefinition.functionName,
 			PathPattern: functionDefinition.path
-		}
+		};
 
 		const sampleDistribution = {
 			Type: 'AWS::CloudFront::Distribution',
@@ -118,7 +118,7 @@ describe('Hooks', () => {
 					}
 				}
 			}
-		}
+		};
 
 		context('Config validation', () => {
 
@@ -213,8 +213,6 @@ describe('Hooks', () => {
 					}
 				}, functionUrlConfig);
 
-				console.log(result.resources.Resources[1])
-				
 				assert.deepStrictEqual(result.resources.Resources[1].LambdaUrlCloudFrontDistribution, sampleDistribution);
 			});
 
@@ -254,7 +252,7 @@ describe('Hooks', () => {
 
 				assert.deepStrictEqual(result.resources.Resources.LambdaUrlCloudFrontDistribution, sampleDistribution);
 			});
-		})
+		});
 
 		context('Route53 record set', () => {
 
@@ -283,11 +281,11 @@ describe('Hooks', () => {
 						Resources: [{ LambdaUrlCloudFrontDistribution: sampleDistribution }, { LambdaUrlRecordSet: sampleRouterRecordSet }]
 					}
 				}, {
-						...functionUrlConfig,
-						functions: [{
-							functionName: 'LambdaUrlTest2',
-							path: '/LambdaUrlTest2'
-						}]
+					...functionUrlConfig,
+					functions: [{
+						functionName: 'LambdaUrlTest2',
+						path: '/LambdaUrlTest2'
+					}]
 				});
 
 				assert.deepStrictEqual(result.resources.Resources, [
@@ -314,6 +312,6 @@ describe('Hooks', () => {
 					{ LambdaUrlRecordSet: sampleRouterRecordSet }
 				]);
 			});
-		})
+		});
 	});
 });

--- a/tests/unit/hooks/function-url.js
+++ b/tests/unit/hooks/function-url.js
@@ -19,7 +19,7 @@ describe('Hooks', () => {
 			functions: [functionDefinition]
 		};
 
-		const resourcesName = 'lambda_url.${self:custom.customDomain.domainName}';
+		const resourcesName = 'lambda_url.${self:custom.customDomain.lambdaUrlDomainName, self:custom.customDomain.domainName}';
 
 		const getSampleOrigin = (functionName = functionDefinition.functionName) => ({
 			DomainName: {
@@ -108,7 +108,7 @@ describe('Hooks', () => {
 		const sampleRouterRecordSet = {
 			Type: 'AWS::Route53::RecordSet',
 			Properties: {
-				HostedZoneName: '${self:custom.customDomain.domainName}.',
+				HostedZoneName: '${self:custom.customDomain.lambdaUrlDomainName, self:custom.customDomain.domainName}.',
 				Type: 'A',
 				Name: resourcesName,
 				AliasTarget: {

--- a/tests/unit/hooks/function-url.js
+++ b/tests/unit/hooks/function-url.js
@@ -96,7 +96,7 @@ describe('Hooks', () => {
 									'arn:aws:acm',
 									'${self:custom.region}',
 									{ Ref: 'AWS::AccountId' },
-									functionUrlConfig.acmCertificate
+									`certificate/${functionUrlConfig.acmCertificate}`
 								]
 							]
 						}


### PR DESCRIPTION
Link al ticket

[Historia](https://janiscommerce.atlassian.net/browse/JC-268)
[Subtarea](https://janiscommerce.atlassian.net/browse/JC-269)

## Descripción del requerimiento
### sls-helper-plugin-janis

Se debe crear un plugin que al procesar un recurso `janis.functionUrl` cree para cada definición recibida:

- distribución de Cloudfront
- RecordSet de Route 53
- Plugin lambdaUrl

La definición de sls  tendría que ser:

```
    [
		"function",
		{
			"functionName": "LambdaUrlTest",
			"handler": "src/lambda/LambdaUrlTest.handler",
			"timeout": 15,
			"url": true
		}
	],
	[
		"function",
		{
			"functionName": "LambdaUrlTest2",
			"handler": "src/lambda/LambdaUrlTest2.handler",
			"timeout": 15,
			"url": true
		}
	],
	[
		"janis.functionUrl",
		{
			"subdomainName": "lambda_url", // el inicio del dominio final ej: lambda_url.commerce.janis.in
			"acmCertificate": "certificate/${param:acmCertificateId}", // certificado para el dominio
			"functions": [
				{
					"functionName": "LambdaUrlTest",
					"path": "/LambdaUrlTest"
				},
				{
					"functionName": "LambdaUrlTest2",
					"path": "/LambdaUrlTest2"
				}
			]
		}
    ]
```


## Descripción de la solución
### Distribución base

Todos los nombres se autogenerarán como el subdominio en camel case seguido de `CloudFrontDistribution`. Ej: Si el dominio es lambda_url , el nombre de la distribución sera `LambdaUrlCloudfrontDistribution`
```
{
		Type: 'AWS::CloudFront::Distribution',
		Properties: {
			DistributionConfig: {
				Enabled: true,
				PriceClass: 'PriceClass_100',
				HttpVersion: 'http2',
				Comment: rawSubdomainName + '.${self:custom.customDomain.domainName}',
				Origins: [],
				CacheBehaviors: [],
				DefaultCacheBehavior: {
					// TargetOriginId: 'NegroLambdaUrlFunction', Buscar forma de que no llegue a ningun recurso valido
					...defaultCache
				},
				Aliases: [
					rawSubdomainName + '.${self:custom.customDomain.domainName}'
				],
				ViewerCertificate: {
					SslSupportMethod: 'sni-only',
					MinimumProtocolVersion: 'TLSv1.2_2019',
					AcmCertificateArn: {
						'Fn::Join': [
							':',
							[
								'arn:aws:acm',
								'${self:custom.region}',
								{ Ref: 'AWS::AccountId' },
								acmCertificate
							]
						]
					}
				}
			}
		}
	}
```
Si ya existe un recurso con ese nombre, en lugar de crear una distribucion se sumara un origen y cache behavior al recurso existente
### Route53

Todos los nombres se autogenerarán como el subdominio en camel case seguido de `RecordSet`. Ej: Si el dominio es **lambda_url** , el nombre de la distribución sera `LambdaUrlRecordSet`

El ejemplo siguiente es siguiendo las definiciones planteadas mas arriba
```
{
	name: 'LambdaUrlRecordSet',
	resource: {
		Type: 'AWS::Route53::RecordSet',
		Properties: {
			HostedZoneName: '${self:custom.customDomain.domainName}.',
			Type: 'A',
			Name: 'lambda_url.${self:custom.cloudfront.lambdaUrl.domainName}',
			AliasTarget: {
				HostedZoneId: 'Z2FDTNDATAQYW2', // Este valor es fijo
				DNSName: {
					'Fn::GetAtt': 'LambdaUrlCloudFrontDistribution.DomainName' // distribucion creada
				}
			}
		}
	}
}
```


Changelog

### Added
- ***Category*** POST API for publish retries
- Retry publish button in ***Category*** Edit view