### PR TITLE
Authorizers fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Now authorizers `UserAuthorizer`, `DevUserAuthorizer` and `ImportExportAuthorizer` requires `janis-client` header
+- Now authorizers `ServiceNoClientAuthorizer`, `AdminNoClientAuthorizer` and `NoClientAuthorizer` uses their own functions
+
+### Removed
+- Unused authorizers `LoggedAuthorizer`, `ApiKeyAuthorizer`, `ImportAuthorizer` and `ExportAuthorizer`
+
 ## [8.0.0] - 2023-06-15
 ### Added
 - Automatic VPC Config for all functions of the service when `LAMBDA_SECURITY_GROUP_ID` and `LAMBDA_SUBNET_IDS` env vars are set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- Now authorizers `UserAuthorizer`, `DevUserAuthorizer` and `ImportExportAuthorizer` requires `janis-client` header
+- Now authorizers `UserAuthorizer`, `DevUserAuthorizer`, `ImportExportAuthorizer`, `AdminNoClientAuthorizer` and `NoClientAuthorizer` requires `janis-client` header
 - Now authorizers `ServiceNoClientAuthorizer`, `AdminNoClientAuthorizer` and `NoClientAuthorizer` uses their own functions
+- Now authorizer `ImportExportAuthorizer` requires `janis-service` header
 
 ### Removed
 - Unused authorizers `LoggedAuthorizer`, `ApiKeyAuthorizer`, `ImportAuthorizer` and `ExportAuthorizer`

--- a/lib/service/authorizers.js
+++ b/lib/service/authorizers.js
@@ -2,15 +2,9 @@
 
 const defaultAuthorizers = require('./default-authorizers');
 
-const authorizersNameToFunctionMapping = {
-	ServiceNoClientAuthorizer: 'ServiceAuthorizer',
-	AdminNoClientAuthorizer: 'AdminAuthorizer',
-	NoClientAuthorizer: 'FullAuthorizer'
-};
-
 const authorizerBuilder = (name, headers, accountId) => ({
 	name,
-	arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-${authorizersNameToFunctionMapping[name] || name}`,
+	arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-${name}`,
 	resultTtlInSeconds: 300,
 	identitySource: headers.map(header => `method.request.header.${header}`).join(','),
 	type: 'request'

--- a/lib/service/default-authorizers.js
+++ b/lib/service/default-authorizers.js
@@ -12,7 +12,7 @@ const fullHeaders = [
 
 module.exports = {
 	FullAuthorizer: fullHeaders,
-	NoClientAuthorizer: baseHeaders,
+	NoClientAuthorizer: fullHeaders,
 
 	ClientAuthorizer: ['janis-client'],
 
@@ -20,10 +20,14 @@ module.exports = {
 	DevUserAuthorizer: fullHeaders,
 
 	AdminAuthorizer: fullHeaders,
-	AdminNoClientAuthorizer: baseHeaders,
+	AdminNoClientAuthorizer: fullHeaders,
 
 	ServiceAuthorizer: fullHeaders,
 	ServiceNoClientAuthorizer: baseHeaders,
 
-	ImportExportAuthorizer: [...fullHeaders, 'janis-entity']
+	ImportExportAuthorizer: [
+		...fullHeaders,
+		'janis-service',
+		'janis-entity'
+	]
 };

--- a/lib/service/default-authorizers.js
+++ b/lib/service/default-authorizers.js
@@ -11,34 +11,19 @@ const fullHeaders = [
 ];
 
 module.exports = {
-
 	FullAuthorizer: fullHeaders,
 	NoClientAuthorizer: baseHeaders,
-	ClientAuthorizer: [
-		'janis-client'
-	],
 
-	LoggedAuthorizer: baseHeaders,
-	ApiKeyAuthorizer: baseHeaders,
-	UserAuthorizer: baseHeaders,
-	DevUserAuthorizer: baseHeaders,
+	ClientAuthorizer: ['janis-client'],
+
+	UserAuthorizer: fullHeaders,
+	DevUserAuthorizer: fullHeaders,
+
 	AdminAuthorizer: fullHeaders,
 	AdminNoClientAuthorizer: baseHeaders,
 
 	ServiceAuthorizer: fullHeaders,
 	ServiceNoClientAuthorizer: baseHeaders,
 
-	ImportExportAuthorizer: [
-		...baseHeaders,
-		'janis-entity'
-	],
-	ImportAuthorizer: [
-		...baseHeaders,
-		'janis-service',
-		'janis-entity'
-	],
-	ExportAuthorizer: [
-		...baseHeaders,
-		'janis-entity'
-	]
+	ImportExportAuthorizer: [...fullHeaders, 'janis-entity']
 };

--- a/tests/unit/hooks/authorizers.js
+++ b/tests/unit/hooks/authorizers.js
@@ -13,6 +13,7 @@ describe('Hooks', () => {
 		const headerClient = 'method.request.header.janis-client';
 		const headerApiKey = 'method.request.header.janis-api-key';
 		const headerApiSecret = 'method.request.header.janis-api-secret';
+		const headerService = 'method.request.header.janis-service';
 		const headerEntity = 'method.request.header.janis-entity';
 
 		const buildAuthorizer = (name, headers, realLambdaFunction) => ({
@@ -27,15 +28,15 @@ describe('Hooks', () => {
 
 		const expectedAuthorizers = {
 			...buildAuthorizer('FullAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
-			...buildAuthorizer('NoClientAuthorizer', [headerApiKey, headerApiSecret]),
+			...buildAuthorizer('NoClientAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
 			...buildAuthorizer('ClientAuthorizer', [headerClient]),
 			...buildAuthorizer('UserAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
 			...buildAuthorizer('DevUserAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
 			...buildAuthorizer('AdminAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
-			...buildAuthorizer('AdminNoClientAuthorizer', [headerApiKey, headerApiSecret]),
+			...buildAuthorizer('AdminNoClientAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
 			...buildAuthorizer('ServiceAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
 			...buildAuthorizer('ServiceNoClientAuthorizer', [headerApiKey, headerApiSecret]),
-			...buildAuthorizer('ImportExportAuthorizer', [headerClient, headerApiKey, headerApiSecret, headerEntity])
+			...buildAuthorizer('ImportExportAuthorizer', [headerClient, headerApiKey, headerApiSecret, headerService, headerEntity])
 		};
 
 		const originalEnvs = { ...process.env };

--- a/tests/unit/hooks/authorizers.js
+++ b/tests/unit/hooks/authorizers.js
@@ -13,121 +13,29 @@ describe('Hooks', () => {
 		const headerClient = 'method.request.header.janis-client';
 		const headerApiKey = 'method.request.header.janis-api-key';
 		const headerApiSecret = 'method.request.header.janis-api-secret';
-		const headerService = 'method.request.header.janis-service';
 		const headerEntity = 'method.request.header.janis-entity';
 
-		const expectedAuthorizers = {
-			FullAuthorizer: {
-				name: 'FullAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-FullAuthorizer`,
+		const buildAuthorizer = (name, headers, realLambdaFunction) => ({
+			[name]: {
+				name,
+				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-${realLambdaFunction || name}`,
 				resultTtlInSeconds: 300,
-				identitySource: `${headerClient},${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			NoClientAuthorizer: {
-				name: 'NoClientAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-FullAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			LoggedAuthorizer: {
-				name: 'LoggedAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-LoggedAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			ApiKeyAuthorizer: {
-				name: 'ApiKeyAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ApiKeyAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			UserAuthorizer: {
-				name: 'UserAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-UserAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			DevUserAuthorizer: {
-				name: 'DevUserAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-DevUserAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			AdminAuthorizer: {
-				name: 'AdminAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-AdminAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerClient},${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			AdminNoClientAuthorizer: {
-				name: 'AdminNoClientAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-AdminAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			ServiceAuthorizer: {
-				name: 'ServiceAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ServiceAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerClient},${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			ServiceNoClientAuthorizer: {
-				name: 'ServiceNoClientAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ServiceAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret}`,
-				type: 'request'
-			},
-
-			ClientAuthorizer: {
-				name: 'ClientAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ClientAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: headerClient,
-				type: 'request'
-			},
-
-			ImportExportAuthorizer: {
-				name: 'ImportExportAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ImportExportAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret},${headerEntity}`,
-				type: 'request'
-			},
-
-			ImportAuthorizer: {
-				name: 'ImportAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ImportAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret},${headerService},${headerEntity}`,
-				type: 'request'
-			},
-
-			ExportAuthorizer: {
-				name: 'ExportAuthorizer',
-				arn: `arn:aws:lambda:us-east-1:${accountId}:function:JanisAuthorizerService-\${self:custom.stage}-ExportAuthorizer`,
-				resultTtlInSeconds: 300,
-				identitySource: `${headerApiKey},${headerApiSecret},${headerEntity}`,
+				identitySource: headers.join(','),
 				type: 'request'
 			}
+		});
+
+		const expectedAuthorizers = {
+			...buildAuthorizer('FullAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
+			...buildAuthorizer('NoClientAuthorizer', [headerApiKey, headerApiSecret]),
+			...buildAuthorizer('ClientAuthorizer', [headerClient]),
+			...buildAuthorizer('UserAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
+			...buildAuthorizer('DevUserAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
+			...buildAuthorizer('AdminAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
+			...buildAuthorizer('AdminNoClientAuthorizer', [headerApiKey, headerApiSecret]),
+			...buildAuthorizer('ServiceAuthorizer', [headerClient, headerApiKey, headerApiSecret]),
+			...buildAuthorizer('ServiceNoClientAuthorizer', [headerApiKey, headerApiSecret]),
+			...buildAuthorizer('ImportExportAuthorizer', [headerClient, headerApiKey, headerApiSecret, headerEntity])
 		};
 
 		const originalEnvs = { ...process.env };

--- a/tests/unit/hooks/state-machine.js
+++ b/tests/unit/hooks/state-machine.js
@@ -480,7 +480,7 @@ describe('Hooks', () => {
 					});
 				});
 
-				it('Should return the service config with the the new param (stateMachine) when the parameters exist in the task', () => {
+				it('Should return the service config with the new param (stateMachine) when the parameters exist in the task', () => {
 
 					const hooksParams = {
 						name: 'MachineName',
@@ -537,7 +537,7 @@ describe('Hooks', () => {
 					});
 				});
 
-				it('Should return the service config with the the new param (stateMachine) when the parameters has a "Payload" in the task', () => {
+				it('Should return the service config with the new param (stateMachine) when the parameters has a "Payload" in the task', () => {
 
 					const hooksParams = {
 						name: 'MachineName',


### PR DESCRIPTION
### Modificaciones
- Los authorizers `UserAuthorizer`, `DevUserAuthorizer`, `ImportExportAuthorizer`, `AdminNoClientAuthorizer` y `NoClientAuthorizer` ahora requieren el header `janis-client`
- Los authorizers usando sus propias funciones del MS Authorizer
  - `ServiceNoClientAuthorizer` no usa más `ServiceAuthorizer`
  - `AdminNoClientAuthorizer` no usa más `AdminAuthorizer`
  - `NoClientAuthorizer` no usa más `FullAuthorizer`
- El authorizer `ImportExportAuthorizer` ahora requiere el header `janis-service`
- Se eliminaron los authorizers `LoggedAuthorizer`, `ApiKeyAuthorizer`, `ImportAuthorizer` y `ExportAuthorizer` porque no se están usando (se validaron las métricas de uso de los Lambda)