### PR TITLE
Jcn 451 totals header 5.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ You can also customize or override every property:
 	'janis-service',
 	'janis-entity',
 	'x-api-key',
+	'x-janis-totals',
+	'x-janis-only-totals',
 	'x-janis-page',
 	'x-janis-page-size'
 ]

--- a/lib/utils/cors.js
+++ b/lib/utils/cors.js
@@ -14,6 +14,8 @@ const DEFAULT_CORS_CONFIG = {
 		'janis-entity',
 		'janis-entity-id',
 		'x-api-key',
+		'x-janis-totals',
+		'x-janis-only-totals',
 		'x-janis-page',
 		'x-janis-page-size'
 	],

--- a/tests/unit/hooks/api-base.js
+++ b/tests/unit/hooks/api-base.js
@@ -547,6 +547,8 @@ describe('Internal Hooks', () => {
 													'janis-entity',
 													'janis-entity-id',
 													'x-api-key',
+													'x-janis-totals',
+													'x-janis-only-totals',
 													'x-janis-page',
 													'x-janis-page-size'
 												],

--- a/tests/unit/hooks/cors.js
+++ b/tests/unit/hooks/cors.js
@@ -25,6 +25,8 @@ describe('Hooks', () => {
 			'janis-entity',
 			'janis-entity-id',
 			'x-api-key',
+			'x-janis-totals',
+			'x-janis-only-totals',
 			'x-janis-page',
 			'x-janis-page-size'
 		];


### PR DESCRIPTION
LINK AL TICKET
[Historia](https://janiscommerce.atlassian.net/browse/JCN-450) | [Subtarea](https://janiscommerce.atlassian.net/browse/JCN-451)

DESCRIPCIÓN DEL REQUERIMIENTO
Actualizar con los nuevos headers de totales en el package de sls-helper-plugin-janis version 5.13.4

DESCRIPCIÓN DE LA SOLUCIÓN
Se actualizaron la lista de Headers para Cors con los nuevos `x-janis-totals` y `x-janis-totals-only`.

**(ATENCION deberia publicarse la versión 5.13.5)**