### PR TITLE
Add new parameter for state machine tasks

### DIFF
--- a/lib/state-machine/index.js
+++ b/lib/state-machine/index.js
@@ -2,6 +2,9 @@
 
 const { camelCase, upperCamelCase } = require('../utils/string');
 
+const stateMachineData = { key: 'stateMachine.$', value: '$$.StateMachine' };
+const stateData = { key: 'state.$', value: '$$.State' };
+
 const addParametersToTask = task => {
 
 	const executeStateMachine = task.Resource === 'arn:aws:states:::states:startExecution';
@@ -9,15 +12,18 @@ const addParametersToTask = task => {
 	if(executeStateMachine)
 		return;
 
-	if(task.Parameters?.Payload)
-		task.Parameters.Payload['stateMachine.$'] = '$$.StateMachine';
-	else if(task.Parameters)
-		task.Parameters['stateMachine.$'] = '$$.StateMachine';
-	else {
+	if(task.Parameters?.Payload) {
+		task.Parameters.Payload[stateMachineData.key] = stateMachineData.value;
+		task.Parameters.Payload[stateData.key] = stateData.value;
+	} else if(task.Parameters) {
+		task.Parameters[stateMachineData.key] = stateMachineData.value;
+		task.Parameters[stateData.key] = stateData.value;
+	} else {
 		task.Parameters = {
 			'session.$': '$.session',
 			'body.$': '$.body',
-			'stateMachine.$': '$$.StateMachine'
+			[stateMachineData.key]: stateMachineData.value,
+			[stateData.key]: stateData.value
 		};
 	}
 };

--- a/tests/unit/hooks/state-machine.js
+++ b/tests/unit/hooks/state-machine.js
@@ -385,7 +385,8 @@ describe('Hooks', () => {
 						definition: definitionWithTask({
 							'session.$': '$.session',
 							'body.$': '$.body',
-							'stateMachine.$': '$$.StateMachine'
+							'stateMachine.$': '$$.StateMachine',
+							'state.$': '$$.State'
 						})
 					};
 
@@ -492,7 +493,8 @@ describe('Hooks', () => {
 						definition: definitionWithTask({
 							'session.$': '$.session',
 							'body.$': '$.body',
-							'stateMachine.$': '$$.StateMachine'
+							'stateMachine.$': '$$.StateMachine',
+							'state.$': '$$.State'
 						})
 					};
 
@@ -552,7 +554,8 @@ describe('Hooks', () => {
 							Payload: {
 								'session.$': '$.session',
 								'body.$': '$.body',
-								'stateMachine.$': '$$.StateMachine'
+								'stateMachine.$': '$$.StateMachine',
+								'state.$': '$$.State'
 							}
 						})
 					};
@@ -648,7 +651,8 @@ describe('Hooks', () => {
 											Parameters: {
 												'session.$': '$.session',
 												'body.$': '$.body',
-												'stateMachine.$': '$$.StateMachine'
+												'stateMachine.$': '$$.StateMachine',
+												'state.$': '$$.State'
 											},
 											End: true
 										}
@@ -739,7 +743,8 @@ describe('Hooks', () => {
 											Parameters: {
 												'session.$': '$.session',
 												'body.$': '$.body',
-												'stateMachine.$': '$$.StateMachine'
+												'stateMachine.$': '$$.StateMachine',
+												'state.$': '$$.State'
 											},
 											End: true
 										}
@@ -919,7 +924,8 @@ describe('Hooks', () => {
 												Parameters: {
 													'session.$': '$.session',
 													'body.$': '$.body',
-													'stateMachine.$': '$$.StateMachine'
+													'stateMachine.$': '$$.StateMachine',
+													'state.$': '$$.State'
 												},
 												End: true
 											}
@@ -933,7 +939,8 @@ describe('Hooks', () => {
 												Parameters: {
 													'session.$': '$.session',
 													'body.$': '$.body',
-													'stateMachine.$': '$$.StateMachine'
+													'stateMachine.$': '$$.StateMachine',
+													'state.$': '$$.State'
 												},
 												End: true
 											}
@@ -1023,7 +1030,8 @@ describe('Hooks', () => {
 												Parameters: {
 													'session.$': '$.session',
 													'body.$': '$.body',
-													'stateMachine.$': '$$.StateMachine'
+													'stateMachine.$': '$$.StateMachine',
+													'state.$': '$$.State'
 												},
 												End: true
 											}
@@ -1143,7 +1151,9 @@ describe('Hooks', () => {
 								Parameters: {
 									'session.$': '$.session',
 									'body.$': '$.body',
-									'stateMachine.$': '$$.StateMachine'
+									'stateMachine.$': '$$.StateMachine',
+									'state.$': '$$.State'
+
 								},
 								Next: 'TrackingCall'
 							},
@@ -1167,7 +1177,8 @@ describe('Hooks', () => {
 															Parameters: {
 																'session.$': '$.session',
 																'body.$': '$.body',
-																'stateMachine.$': '$$.StateMachine'
+																'stateMachine.$': '$$.StateMachine',
+																'state.$': '$$.State'
 															},
 															End: true
 														}
@@ -1186,7 +1197,8 @@ describe('Hooks', () => {
 													Payload: {
 														'session.$': '$.session',
 														'body.$': '$.body',
-														'stateMachine.$': '$$.StateMachine'
+														'stateMachine.$': '$$.StateMachine',
+														'state.$': '$$.State'
 													}
 												},
 												End: true


### PR DESCRIPTION
**Link al ticket**

[Historia](https://janiscommerce.atlassian.net/browse/JCN-466)

[Subtarea](https://janiscommerce.atlassian.net/browse/JCN-468)

**Descripción del requerimiento**

Se debe ajustar función la addParametersToTask del package de [sls-helper-plugin-janis](https://github.com/jormaechea/sls-helper-plugin-janis) para que se pueda pasar un parámetro nuevo para que le llegue a las tasks de las state-machines. 

Esta debe ser  la property `State`  del contexto de la step de la state-machine ([Context object - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/input-output-contextobject.html) )

**Descripción de la solución**

Se modificó la función `addParametersToTask` para agregar una nueva property a los parameters de las tasks de las state-machines. Esta es la prop `State`, tomándola del contexto de la tasks de la step-machine, como lo hace con la property `StateMachine`

**Changelog**

### Added
- Add new property for tasks parameters in addParametersToTask function