### PR TITLE
Remove JANIS_TRACE_EXTENSION_ENABLED when skipTraceLayer is true

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -9,6 +9,7 @@ const { getFileDirFromApiPath } = require('../utils/fs');
 const validateAuthorizer = require('../utils/validate-authorizer');
 const { parseFunctionLayers } = require('../utils/parse-function-layers');
 const { upperCamelCase } = require('../utils/string');
+const { removeTraceLayerEnv } = require('../utils/trace-layer');
 
 const INTEGRATION = 'lambda';
 
@@ -101,6 +102,7 @@ const apiBase = (serviceConfig, {
 			}
 		}],
 		...parseFunctionLayers(layers, addLayers, skipTraceLayer, serviceConfig),
+		...removeTraceLayerEnv(skipTraceLayer),
 		...functionRawProps
 	};
 

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -102,8 +102,8 @@ const apiBase = (serviceConfig, {
 			}
 		}],
 		...parseFunctionLayers(layers, addLayers, skipTraceLayer, serviceConfig),
-		...removeTraceLayerEnv(skipTraceLayer),
-		...functionRawProps
+		...functionRawProps,
+		...removeTraceLayerEnv(skipTraceLayer, functionRawProps?.environment)
 	};
 
 	if(pkg && pkg.include)

--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -10,6 +10,7 @@ const buildCors = require('../utils/cors');
 
 const validateAuthorizer = require('../utils/validate-authorizer');
 const { parseFunctionLayers } = require('../utils/parse-function-layers');
+const { removeTraceLayerEnv } = require('../utils/trace-layer');
 
 const INTEGRATION = 'lambda';
 
@@ -92,6 +93,7 @@ const apiBase = ({
 			]
 		},
 		...parseFunctionLayers(layers, addLayers, skipTraceLayer, serviceConfig),
+		...removeTraceLayerEnv(skipTraceLayer),
 		events: [{
 			http: {
 				...event,

--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -82,8 +82,6 @@ const apiBase = ({
 
 	functionName = functionName || `${getFunctionNamePrefix(methodName)}-${entityNameAsTitle.replace(/ /g, '')}`;
 
-	console.log({ functionRawProps });
-
 	const functionConfiguration = {
 		name: `API-\${self:custom.serviceName}-${functionName}-\${self:custom.stage}`,
 		handler: handler || 'src/lambda/RestApi/index.handler',

--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -82,6 +82,8 @@ const apiBase = ({
 
 	functionName = functionName || `${getFunctionNamePrefix(methodName)}-${entityNameAsTitle.replace(/ /g, '')}`;
 
+	console.log({ functionRawProps });
+
 	const functionConfiguration = {
 		name: `API-\${self:custom.serviceName}-${functionName}-\${self:custom.stage}`,
 		handler: handler || 'src/lambda/RestApi/index.handler',
@@ -93,14 +95,14 @@ const apiBase = ({
 			]
 		},
 		...parseFunctionLayers(layers, addLayers, skipTraceLayer, serviceConfig),
-		...removeTraceLayerEnv(skipTraceLayer),
 		events: [{
 			http: {
 				...event,
 				...eventRawProps
 			}
 		}],
-		...functionRawProps
+		...functionRawProps,
+		...removeTraceLayerEnv(skipTraceLayer, functionRawProps?.environment)
 	};
 
 	if(pkg && pkg.include)

--- a/lib/event-listener/index.js
+++ b/lib/event-listener/index.js
@@ -6,6 +6,7 @@ const { kebabCase, titleCase } = require('../utils/string');
 
 const validateAuthorizer = require('../utils/validate-authorizer');
 const { parseFunctionLayers } = require('../utils/parse-function-layers');
+const { removeTraceLayerEnv } = require('../utils/trace-layer');
 
 const INTEGRATION = 'lambda';
 
@@ -58,6 +59,7 @@ const eventListener = ({
 			}
 		],
 		...parseFunctionLayers(layers, addLayers, skipTraceLayer, serviceConfig),
+		...removeTraceLayerEnv(skipTraceLayer),
 		...functionRawProps
 	};
 

--- a/lib/event-listener/index.js
+++ b/lib/event-listener/index.js
@@ -59,8 +59,8 @@ const eventListener = ({
 			}
 		],
 		...parseFunctionLayers(layers, addLayers, skipTraceLayer, serviceConfig),
-		...removeTraceLayerEnv(skipTraceLayer),
-		...functionRawProps
+		...functionRawProps,
+		...removeTraceLayerEnv(skipTraceLayer, functionRawProps?.environment)
 	};
 
 	if(pkg && pkg.include)

--- a/lib/service/base.js
+++ b/lib/service/base.js
@@ -8,6 +8,7 @@ const { LOG_FORMAT, LOG_REST_API_CONFIG } = require('../utils/api-gateway-logs-d
 const { shouldAddTraceLayer, getTraceLayerArn } = require('../utils/trace-layer');
 const { shouldAddVPCConfig, getVPCConfig } = require('../utils/vpc');
 const { defaultTags } = require('../utils/default-tags');
+const defaultEnvVars = require('../utils/default-env-vars');
 
 const defaultInclude = [
 	'src/config/*',
@@ -152,10 +153,8 @@ module.exports = ({
 			apiName: 'JANIS ${param:humanReadableStage} ${self:custom.serviceTitle} API',
 			logRetentionInDays: 14,
 			environment: {
-				JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-				JANIS_ENV: '${self:custom.stage}',
-				MS_PATH: 'src',
-				...shouldAddTraceLayer() ? { JANIS_TRACE_EXTENSION_ENABLED: 'true' } : {}
+				...defaultEnvVars,
+				...shouldAddTraceLayer() && { JANIS_TRACE_EXTENSION_ENABLED: 'true' }
 			},
 			tags: serviceTags,
 			stackTags: serviceTags,

--- a/lib/utils/default-env-vars.js
+++ b/lib/utils/default-env-vars.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+	JANIS_ENV: '${self:custom.stage}',
+	MS_PATH: 'src'
+};

--- a/lib/utils/trace-layer.js
+++ b/lib/utils/trace-layer.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const defaultEnvVars = require('./default-env-vars');
-
 const shouldAddTraceLayer = () => process.env.TRACE_ACCOUNT_ID && process.env.JANIS_TRACE_EXTENSION_VERSION;
 
 const getTraceLayerArn = () => {
@@ -15,8 +13,6 @@ module.exports.getTraceLayerArn = getTraceLayerArn;
 
 module.exports.removeTraceLayer = layers => layers.filter(layerArn => layerArn !== getTraceLayerArn());
 
-module.exports.removeTraceLayerEnv = (skipTraceLayer = false) => {
-	return shouldAddTraceLayer() && skipTraceLayer
-		? { environment: { ...defaultEnvVars } }
-		: {};
-};
+module.exports.removeTraceLayerEnv = (skipTraceLayer = false, environment = {}) => ({
+	...shouldAddTraceLayer() && skipTraceLayer ? { environment: { ...environment, JANIS_TRACE_EXTENSION_ENABLED: '' } } : {}
+});

--- a/lib/utils/trace-layer.js
+++ b/lib/utils/trace-layer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const defaultEnvVars = require('./default-env-vars');
+
 const shouldAddTraceLayer = () => process.env.TRACE_ACCOUNT_ID && process.env.JANIS_TRACE_EXTENSION_VERSION;
 
 const getTraceLayerArn = () => {
@@ -12,3 +14,9 @@ module.exports.shouldAddTraceLayer = shouldAddTraceLayer;
 module.exports.getTraceLayerArn = getTraceLayerArn;
 
 module.exports.removeTraceLayer = layers => layers.filter(layerArn => layerArn !== getTraceLayerArn());
+
+module.exports.removeTraceLayerEnv = (skipTraceLayer = false) => {
+	return shouldAddTraceLayer() && skipTraceLayer
+		? { environment: { ...defaultEnvVars } }
+		: {};
+};

--- a/tests/unit/hooks/api-base.js
+++ b/tests/unit/hooks/api-base.js
@@ -777,9 +777,7 @@ describe('Internal Hooks', () => {
 									]
 								},
 								environment: {
-									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-									JANIS_ENV: '${self:custom.stage}',
-									MS_PATH: 'src'
+									JANIS_TRACE_EXTENSION_ENABLED: ''
 								},
 								events: [
 									{
@@ -840,9 +838,7 @@ describe('Internal Hooks', () => {
 									]
 								},
 								environment: {
-									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-									JANIS_ENV: '${self:custom.stage}',
-									MS_PATH: 'src'
+									JANIS_TRACE_EXTENSION_ENABLED: ''
 								},
 								events: [
 									{
@@ -892,9 +888,7 @@ describe('Internal Hooks', () => {
 									]
 								},
 								environment: {
-									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-									JANIS_ENV: '${self:custom.stage}',
-									MS_PATH: 'src'
+									JANIS_TRACE_EXTENSION_ENABLED: ''
 								},
 								events: [
 									{
@@ -958,9 +952,7 @@ describe('Internal Hooks', () => {
 									]
 								},
 								environment: {
-									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-									JANIS_ENV: '${self:custom.stage}',
-									MS_PATH: 'src'
+									JANIS_TRACE_EXTENSION_ENABLED: ''
 								},
 								events: [
 									{
@@ -1251,7 +1243,8 @@ describe('Internal Hooks', () => {
 				}, {
 					entityName: 'product attribute',
 					addLayers: ['CustomLayer'],
-					skipTraceLayer: true
+					skipTraceLayer: true,
+					functionRawProps: { environment: { MY_CUSTOM_VAR: '1' } }
 				});
 
 				assert.deepStrictEqual(serviceConfig, {
@@ -1278,9 +1271,8 @@ describe('Internal Hooks', () => {
 									]
 								},
 								environment: {
-									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
-									JANIS_ENV: '${self:custom.stage}',
-									MS_PATH: 'src'
+									JANIS_TRACE_EXTENSION_ENABLED: '',
+									MY_CUSTOM_VAR: '1'
 								},
 								events: [
 									{

--- a/tests/unit/hooks/api-base.js
+++ b/tests/unit/hooks/api-base.js
@@ -776,6 +776,11 @@ describe('Internal Hooks', () => {
 										'src/models/product-attribute.js'
 									]
 								},
+								environment: {
+									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+									JANIS_ENV: '${self:custom.stage}',
+									MS_PATH: 'src'
+								},
 								events: [
 									{
 										http: {
@@ -834,6 +839,11 @@ describe('Internal Hooks', () => {
 										'src/models/product-attribute.js'
 									]
 								},
+								environment: {
+									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+									JANIS_ENV: '${self:custom.stage}',
+									MS_PATH: 'src'
+								},
 								events: [
 									{
 										http: {
@@ -880,6 +890,11 @@ describe('Internal Hooks', () => {
 										'src/api/product-attribute/get.js',
 										'src/models/product-attribute.js'
 									]
+								},
+								environment: {
+									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+									JANIS_ENV: '${self:custom.stage}',
+									MS_PATH: 'src'
 								},
 								events: [
 									{
@@ -941,6 +956,11 @@ describe('Internal Hooks', () => {
 										'src/api/product-attribute/get.js',
 										'src/models/product-attribute.js'
 									]
+								},
+								environment: {
+									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+									JANIS_ENV: '${self:custom.stage}',
+									MS_PATH: 'src'
 								},
 								events: [
 									{
@@ -1257,6 +1277,11 @@ describe('Internal Hooks', () => {
 										'src/models/product-attribute.js'
 									]
 								},
+								environment: {
+									JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
+									JANIS_ENV: '${self:custom.stage}',
+									MS_PATH: 'src'
+								},
 								events: [
 									{
 										http: {
@@ -1276,7 +1301,7 @@ describe('Internal Hooks', () => {
 				});
 			});
 
-			it('Should not set function layers if layers is not set, addLayers is not set or empty and skipTraceLayerskipTraceLayer is false', () => {
+			it('Should not set function layers if layers is not set, addLayers is not set or empty and skipTraceLayer is false', () => {
 
 				sinon.stub(process, 'env')
 					.value({


### PR DESCRIPTION
Ahora cuando se `skipTraceLayer` es **true**, se envía `JANIS_TRACE_EXTENSION_ENABLED` como string vacío en las variables de entorno de cada función.
ℹ️ Esto pasa por default para las `janis.apiGet` y `janis.apiList`, pero podría enviarse en algún otro hook.
Se tuvo cuidado con las variables que se pueden enviar en `functionRawProps.environment`, mergeandolas si llegan