### PR TITLE
Added SQS FIFO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Both `consumerProperties`and `dlqConsumerProperties` fields can be customized wi
 - `description`: _default_: `[name] SQS Queue Consumer` | Change the function description.
 - `batchSize`: _default_: 1 (only for main consumer) | Change the SQS consumer batch Size.
 - `maximumBatchingWindow`: _default_: 10 (only for main consumer) | Change the SQS consumer maximum batching window.
+- `prefixPath`: _String_: To add optional prefix path after `src/sqs-consumer`. e.g. `src/sqs-consumer/[prefixPath]/[name in lowerCase]-consumer.handler`
 
 Some other properties
 - `functionProperties`: _Object_ | To add other properties to the function (the same one in `function` hook).
@@ -355,6 +356,12 @@ Both `mainQueueProperties`and `dlqQueueProperties` fields can be customized with
 - `visibilityTimeout`: _default_: 60 (main queue) or 20 (dlq).
 - `messageRetentionPeriod`: _default_: 864000 (only for DLQ).
 
+FIFO properties (since _9.6.0_)
+- `fifoQueue`: _boolean_ | If set to `true`, creates a FIFO queue.
+- `contentBasedDeduplication`: _boolean_ | Specifies whether to enable content-based deduplication.
+- `fifoThroughputLimit`: _string_ | Valid values are `perQueue` and `perMessageGroupId`.
+- `deduplicationScope`: _string_ | Valid values are `queue` and `messageGroup`.
+
 **Returns**: _array_ of Hooks
 
 #### Consumer Files
@@ -364,12 +371,19 @@ If handler's location don't change (uses default values), the files must be loca
 * `src/sqs-consumer/[name-in-kebab-case]-consumer.js` for main queue consumer
 * `src/sqs-consumer/[name-in-kebab-case]-dlq-consumer.js` for dlq consumer
 
+If `prefixPath` received the location will be
+
+* `src/sqs-consumer/[prefixPath]/[name-in-kebab-case]-consumer.js` for main queue consumer
+* `src/sqs-consumer/[prefixPath]/[name-in-kebab-case]-dlq-consumer.js` for dlq consumer
+
 #### SQS URL Env Vars
 
 Environment Variables will be created for SQS URLs (both):
 
 * `[NAME_IN_SNAKE_CASE]_SQS_QUEUE_URL` for main queue consumer
 * `[NAME_IN_SNAKE_CASE]_DLQ_SQS_QUEUE_URL` for dlq consumer
+
+> FIFO queues uses the same Environment Variables as Standard queues.
 
 #### Quick hook example
 

--- a/lib/sqs-helper/helper/add-fifo-suffix.js
+++ b/lib/sqs-helper/helper/add-fifo-suffix.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = value => `${value}.fifo`;

--- a/lib/sqs-helper/helper/default.js
+++ b/lib/sqs-helper/helper/default.js
@@ -22,6 +22,10 @@ const mainQueueDefaultsValue = {
 	visibilityTimeout: 90
 };
 
+const dlqConsumerDefaultsValue = {
+	timeout: 15
+};
+
 const dlqQueueDefaultsValue = {
 	// Enable long polling, allowing AWS to wait 20 seconds each time it queries the queue
 	receiveMessageWaitTimeSeconds: 20,
@@ -34,6 +38,7 @@ const dlqQueueDefaultsValue = {
 module.exports = {
 	consumerDefaultsValue,
 	mainQueueDefaultsValue,
+	dlqConsumerDefaultsValue,
 	dlqQueueDefaultsValue,
 	// eslint-disable-next-line no-template-curly-in-string
 	baseArn: 'arn:aws:sqs:${aws:region}:${aws:accountId}',

--- a/lib/sqs-helper/helper/generate-arns.js
+++ b/lib/sqs-helper/helper/generate-arns.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { baseArn } = require('./default');
+const addFifoSuffix = require('./add-fifo-suffix');
+
+module.exports = (sqsName, dlqName, fifoQueue) => {
+	return {
+		sqsArn: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(sqsName) : sqsName}`,
+		dlqArn: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(dlqName) : dlqName}`
+	};
+};

--- a/lib/sqs-helper/helper/generate-names.js
+++ b/lib/sqs-helper/helper/generate-names.js
@@ -13,5 +13,4 @@ module.exports = name => {
 		sqsName: `${titleName}Queue`,
 		dlqName: `${titleName}DLQ`
 	};
-
 };

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -5,11 +5,15 @@ const generateQueueNames = require('./helper/generate-names');
 const {
 	consumerDefaultsValue,
 	mainQueueDefaultsValue,
+	dlqConsumerDefaultsValue,
 	dlqQueueDefaultsValue,
 	baseArn,
 	baseUrl
 } = require('./helper/default');
+
 const { defaultTags } = require('../utils/default-tags');
+const addFifoSuffix = require('./helper/add-fifo-suffix');
+const generateArns = require('./helper/generate-arns');
 
 module.exports = class SQSHelper {
 
@@ -38,6 +42,8 @@ module.exports = class SQSHelper {
 			dlqConsumerProperties
 		} = this.getConfigsProperties(configs);
 
+		const fifoQueue = !!mainQueueProperties.fifoQueue;
+
 		const {
 			titleName,
 			sqsName,
@@ -46,35 +52,46 @@ module.exports = class SQSHelper {
 			envVarName
 		} = generateQueueNames(name);
 
+		const {
+			sqsArn, dlqArn
+		} = generateArns(sqsName, dlqName, fifoQueue);
+
 		return [
 
-			this.getSQSUrlEnvVars(envVarName, sqsName, dlqName),
+			this.getSQSUrlEnvVars(envVarName, sqsName, dlqName, fifoQueue),
 
 			this.buildConsumerFunction(titleName, {
 				...consumerProperties,
 				filename,
-				sqsName
+				queueName: sqsName,
+				queueArn: sqsArn,
+				fifoQueue
 			}),
 
 			this.buildQueueResource(sqsName, {
 				...mainQueueProperties,
 				titleName,
-				dlqName
+				dlqName,
+				dlqArn,
+				fifoQueue
 			}),
 
 			this.buildQueueResource(dlqName, {
 				...dlqQueueProperties,
 				titleName,
-				isDLQ: true
+				isDLQ: true,
+				fifoQueue
 			}),
 
-			...Object.keys(dlqConsumerProperties).length ? [this.buildConsumerFunction(`${titleName}DLQ`, {
-				filename: `${filename}-dlq`,
-				timeout: 15,
-				...dlqConsumerProperties,
-				sqsName: dlqName
-			})] : []
-
+			...configs.dlqConsumerProperties && Object.keys(configs.dlqConsumerProperties).length
+				? [this.buildConsumerFunction(titleName, {
+					...dlqConsumerProperties,
+					filename,
+					queueName: dlqName,
+					queueArn: dlqArn,
+					isDLQ: true,
+					fifoQueue
+				})] : []
 		];
 	}
 
@@ -96,18 +113,19 @@ module.exports = class SQSHelper {
 
 	static getConfigsProperties(configs) {
 
-		const {
-			name,
-			dlqConsumerProperties = {}
-		} = configs;
-
 		const consumerProperties = {
 			...consumerDefaultsValue,
 			...configs.consumerProperties
 		};
+
 		const mainQueueProperties = {
 			...mainQueueDefaultsValue,
 			...configs.mainQueueProperties
+		};
+
+		const dlqConsumerProperties = {
+			...dlqConsumerDefaultsValue,
+			...configs.dlqConsumerProperties
 		};
 
 		const dlqQueueProperties = {
@@ -116,7 +134,7 @@ module.exports = class SQSHelper {
 		};
 
 		return {
-			name,
+			name: configs.name,
 			consumerProperties,
 			mainQueueProperties,
 			dlqQueueProperties,
@@ -124,18 +142,21 @@ module.exports = class SQSHelper {
 		};
 	}
 
-	static getSQSUrlEnvVars(name, sqsName, dlqName) {
+	static getSQSUrlEnvVars(name, sqsName, dlqName, fifoQueue) {
 		return ['envVars', {
-			[`${name}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${sqsName}`,
-			[`${name}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${dlqName}`
+			[`${name}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(sqsName) : sqsName}`,
+			[`${name}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(dlqName) : dlqName}`
 		}];
 	}
 
 	static buildConsumerFunction(functionName, {
+		isDLQ,
+		prefixPath,
 		filename,
-		timeout,
-		sqsName,
 		handler,
+		timeout,
+		queueName,
+		queueArn,
 		description,
 		functionProperties,
 		rawProperties,
@@ -144,19 +165,27 @@ module.exports = class SQSHelper {
 		eventProperties
 	}) {
 
+		if(isDLQ) {
+			functionName = `${functionName}DLQ`;
+			filename = `${filename}-dlq`;
+		}
+
+		if(prefixPath)
+			filename = `${prefixPath}/${filename}`;
+
 		return ['function', {
 			functionName: `${functionName}QueueConsumer`,
 			handler: handler || `src/sqs-consumer/${filename}-consumer.handler`,
 			description: description || `${functionName} SQS Queue Consumer`,
 			timeout,
 			rawProperties: {
-				dependsOn: [sqsName],
+				dependsOn: [queueName],
 				...rawProperties
 			},
 			events: [
 				{
 					sqs: {
-						arn: `${baseArn}:\${self:custom.serviceName}${sqsName}`,
+						arn: queueArn,
 						functionResponseType: 'ReportBatchItemFailures',
 						...batchSize && { batchSize },
 						...maximumBatchingWindow && { maximumBatchingWindow },
@@ -173,44 +202,42 @@ module.exports = class SQSHelper {
 		titleName,
 		maxReceiveCount,
 		dlqName,
+		dlqArn,
 		receiveMessageWaitTimeSeconds,
 		visibilityTimeout,
 		messageRetentionPeriod,
+		fifoQueue,
+		fifoThroughputLimit,
+		contentBasedDeduplication,
+		deduplicationScope,
 		...extraProperties
 	}) {
-
-		const queueName = `\${self:custom.serviceName}${name}`;
-
-		const queueTags = [...defaultTags];
-		queueTags.push({
-			Key: 'SQSConstruct',
-			Value: titleName
-		});
-
-		if(isDLQ) {
-			queueTags.push({
-				Key: 'IsDLQ',
-				Value: 'true'
-			});
-		}
 
 		return ['resource', {
 			name,
 			resource: {
 				Type: 'AWS::SQS::Queue',
 				Properties: {
-					QueueName: queueName,
+					QueueName: `\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(name) : name}`,
 					ReceiveMessageWaitTimeSeconds: receiveMessageWaitTimeSeconds,
 					VisibilityTimeout: visibilityTimeout,
 					// eslint-disable-next-line max-len
 					...dlqName && {
 						RedrivePolicy: JSON.stringify({
 							maxReceiveCount,
-							deadLetterTargetArn: `${baseArn}:\${self:custom.serviceName}${dlqName}`
+							deadLetterTargetArn: dlqArn
 						})
 					},
 					...messageRetentionPeriod && { MessageRetentionPeriod: messageRetentionPeriod },
-					Tags: queueTags,
+					...fifoQueue && { FifoQueue: true },
+					...fifoQueue && fifoThroughputLimit && { FifoThroughputLimit: fifoThroughputLimit },
+					...fifoQueue && deduplicationScope && { DeduplicationScope: deduplicationScope },
+					...fifoQueue && contentBasedDeduplication && { ContentBasedDeduplication: true },
+					Tags: [
+						...defaultTags,
+						{ Key: 'SQSConstruct', Value: titleName },
+						...isDLQ ? [{ Key: 'IsDLQ', Value: 'true' }] : []
+					],
 					...extraProperties
 				},
 				...dlqName && { DependsOn: [dlqName] }


### PR DESCRIPTION
Se sumaron las properties específicas de las FIFO
Los cambios son
- Nuevas props para las queues: `fifoQueue`, `fifoThroughputLimit`, `deduplicationScope`, `contentBasedDeduplication`
- Para las FIFO se suma el nombre `.fifo` a la QueueName y al `arn`
- Para los consumer se sumó la prop opcional `prefixPath` para organizar mejor los archivos de `sqs-consumer`

ℹ️ Mucho cambio de código, pero solo cambia para las FIFO, los tests quedaron iguales salvo el nuevo.