### PR TITLE
Delay Queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ To use the hook Builder of:
 - DLQ Queue
 - Delayed Queue (optional). Since _9.7.0_
 - Main Consumer
-- DLQ Consumer (optional). Since _9.7.0_
-- Delayed Consumer (optional)
+- DLQ Consumer (optional)
+- Delayed Consumer (optional). Since _9.7.0_
 - Env Vars for SQS Urls
 
 You can use `SQSHelper.buildHooks(configs)` method. This will create an _array_ of Hooks with the proper data.

--- a/lib/sqs-helper/helper/add-fifo-suffix.js
+++ b/lib/sqs-helper/helper/add-fifo-suffix.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = value => `${value}.fifo`;

--- a/lib/sqs-helper/helper/default.js
+++ b/lib/sqs-helper/helper/default.js
@@ -22,6 +22,12 @@ const mainQueueDefaultsValue = {
 	visibilityTimeout: 90
 };
 
+const delayQueueDefaultsValue = {
+	...mainQueueDefaultsValue,
+	// The time in seconds for which the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900 (15 minutes).
+	delaySeconds: 300
+};
+
 const dlqConsumerDefaultsValue = {
 	timeout: 15
 };
@@ -38,6 +44,7 @@ const dlqQueueDefaultsValue = {
 module.exports = {
 	consumerDefaultsValue,
 	mainQueueDefaultsValue,
+	delayQueueDefaultsValue,
 	dlqConsumerDefaultsValue,
 	dlqQueueDefaultsValue,
 	// eslint-disable-next-line no-template-curly-in-string

--- a/lib/sqs-helper/helper/fix-fifo-name.js
+++ b/lib/sqs-helper/helper/fix-fifo-name.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = (name, fifoQueue) => (fifoQueue ? `${name}.fifo` : name);

--- a/lib/sqs-helper/helper/generate-arns.js
+++ b/lib/sqs-helper/helper/generate-arns.js
@@ -3,9 +3,10 @@
 const { baseArn } = require('./default');
 const addFifoSuffix = require('./add-fifo-suffix');
 
-module.exports = (sqsName, dlqName, fifoQueue) => {
+module.exports = ({ mainQueue, delayedQueue, dlq }, fifoQueue) => {
 	return {
-		sqsArn: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(sqsName) : sqsName}`,
-		dlqArn: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(dlqName) : dlqName}`
+		mainQueue: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(mainQueue) : mainQueue}`,
+		delayedQueue: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(delayedQueue) : delayedQueue}`,
+		dlq: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(dlq) : dlq}`
 	};
 };

--- a/lib/sqs-helper/helper/generate-arns.js
+++ b/lib/sqs-helper/helper/generate-arns.js
@@ -3,10 +3,10 @@
 const { baseArn } = require('./default');
 const fixFifoName = require('./fix-fifo-name');
 
-module.exports = ({ mainQueue, delayedQueue, dlq }, fifoQueue) => {
+module.exports = ({ mainQueue, delayQueue, dlq }, fifoQueue) => {
 	return {
 		mainQueue: `${baseArn}:\${self:custom.serviceName}${fixFifoName(mainQueue, fifoQueue)}`,
-		delayedQueue: `${baseArn}:\${self:custom.serviceName}${fixFifoName(delayedQueue, fifoQueue)}`,
+		delayQueue: `${baseArn}:\${self:custom.serviceName}${fixFifoName(delayQueue, fifoQueue)}`,
 		dlq: `${baseArn}:\${self:custom.serviceName}${fixFifoName(dlq, fifoQueue)}`
 	};
 };

--- a/lib/sqs-helper/helper/generate-arns.js
+++ b/lib/sqs-helper/helper/generate-arns.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const { baseArn } = require('./default');
-const addFifoSuffix = require('./add-fifo-suffix');
+const fixFifoName = require('./fix-fifo-name');
 
 module.exports = ({ mainQueue, delayedQueue, dlq }, fifoQueue) => {
 	return {
-		mainQueue: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(mainQueue) : mainQueue}`,
-		delayedQueue: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(delayedQueue) : delayedQueue}`,
-		dlq: `${baseArn}:\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(dlq) : dlq}`
+		mainQueue: `${baseArn}:\${self:custom.serviceName}${fixFifoName(mainQueue, fifoQueue)}`,
+		delayedQueue: `${baseArn}:\${self:custom.serviceName}${fixFifoName(delayedQueue, fifoQueue)}`,
+		dlq: `${baseArn}:\${self:custom.serviceName}${fixFifoName(dlq, fifoQueue)}`
 	};
 };

--- a/lib/sqs-helper/helper/generate-names.js
+++ b/lib/sqs-helper/helper/generate-names.js
@@ -11,7 +11,7 @@ module.exports = name => {
 		filename: kebabCase(name),
 		envVarName: upperSnakeCase(name),
 		mainQueue: `${titleName}Queue`,
-		delayedQueue: `${titleName}DelayedQueue`,
+		delayQueue: `${titleName}DelayQueue`,
 		dlq: `${titleName}DLQ`
 	};
 };

--- a/lib/sqs-helper/helper/generate-names.js
+++ b/lib/sqs-helper/helper/generate-names.js
@@ -10,7 +10,8 @@ module.exports = name => {
 		titleName,
 		filename: kebabCase(name),
 		envVarName: upperSnakeCase(name),
-		sqsName: `${titleName}Queue`,
-		dlqName: `${titleName}DLQ`
+		mainQueue: `${titleName}Queue`,
+		delayedQueue: `${titleName}DelayedQueue`,
+		dlq: `${titleName}DLQ`
 	};
 };

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -7,6 +7,7 @@ const generateQueueNames = require('./helper/generate-names');
 const {
 	consumerDefaultsValue,
 	mainQueueDefaultsValue,
+	delayQueueDefaultsValue,
 	dlqConsumerDefaultsValue,
 	dlqQueueDefaultsValue,
 	baseArn,
@@ -38,16 +39,16 @@ module.exports = class SQSHelper {
 
 		this.setConfigsWithDefaults(configs);
 
-		const delayedHooks = [];
+		const delayHooks = [];
 
-		if(this.useDelayedQueue) {
+		if(this.useDelayQueue) {
 
-			// is used this.delayedConsumerProperties cause must have a consumer (the own consumer or the main consumer)
-			// this.delayedConsumerProperties has default mainConsumer configs
-			if(this.shouldAddConsumer(this.delayedConsumerProperties))
-				delayedHooks.push(this.buildConsumerFunction(this.delayedConsumerProperties, { delayedConsumer: true }));
+			// is used this.delayConsumerProperties cause must have a consumer (the own consumer or the main consumer)
+			// this.delayConsumerProperties has default mainConsumer configs
+			if(this.shouldAddConsumer(this.delayConsumerProperties))
+				delayHooks.push(this.buildConsumerFunction(this.delayConsumerProperties, { delayConsumer: true }));
 
-			delayedHooks.push(this.buildQueueResource(this.delayedQueueProperties, { delayedQueue: true }));
+			delayHooks.push(this.buildQueueResource(this.delayQueueProperties, { delayQueue: true }));
 		}
 
 		return [
@@ -58,7 +59,7 @@ module.exports = class SQSHelper {
 
 			this.buildQueueResource(this.mainQueueProperties, { mainQueue: true }),
 
-			...delayedHooks,
+			...delayHooks,
 
 			this.buildQueueResource(this.dlqQueueProperties, { dlq: true }),
 
@@ -76,8 +77,8 @@ module.exports = class SQSHelper {
 		[
 			['Main Consumer', configs.consumerProperties],
 			['Main Queue', configs.mainQueueProperties],
-			['Delayed Consumer', configs.delayedConsumerProperties],
-			['Delayed Queue', configs.delayedQueueProperties],
+			['Delay Consumer', configs.delayConsumerProperties],
+			['Delay Queue', configs.delayQueueProperties],
 			['DLQ Consumer', configs.dlqConsumerProperties],
 			['DLQ Queue', configs.dlqQueueProperties]
 		].forEach(([type, properties]) => {
@@ -91,15 +92,15 @@ module.exports = class SQSHelper {
 		this.consumerProperties = { ...consumerDefaultsValue, ...userConfigs.consumerProperties };
 		this.mainQueueProperties = { ...mainQueueDefaultsValue, ...userConfigs.mainQueueProperties };
 
-		// delayed queue and consumer uses main config by default
-		this.delayedConsumerProperties = { ...consumerDefaultsValue, ...userConfigs.delayedConsumerProperties };
-		this.delayedQueueProperties = { ...mainQueueDefaultsValue, ...userConfigs.delayedQueueProperties };
+		// delay queue and consumer uses main config by default
+		this.delayConsumerProperties = { ...consumerDefaultsValue, ...userConfigs.delayConsumerProperties };
+		this.delayQueueProperties = { ...delayQueueDefaultsValue, ...userConfigs.delayQueueProperties };
 
 		this.dlqConsumerProperties = { ...dlqConsumerDefaultsValue, ...userConfigs.dlqConsumerProperties };
 		this.dlqQueueProperties = { ...dlqQueueDefaultsValue, ...userConfigs.dlqQueueProperties };
 
 		this.fifoQueue = !!userConfigs.mainQueueProperties?.fifoQueue;
-		this.useDelayedQueue = !!userConfigs.delayedQueueProperties;
+		this.useDelayQueue = !!userConfigs.delayQueueProperties;
 
 		this.names = generateQueueNames(userConfigs.name);
 
@@ -117,8 +118,8 @@ module.exports = class SQSHelper {
 			[`${this.names.envVarName}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.mainQueue, this.fifoQueue)}`,
 			[`${this.names.envVarName}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.dlq, this.fifoQueue)}`,
 
-			...this.useDelayedQueue && {
-				[`${this.names.envVarName}_DELAYED_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.delayedQueue, this.fifoQueue)}`
+			...this.useDelayQueue && {
+				[`${this.names.envVarName}_DELAY_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.delayQueue, this.fifoQueue)}`
 			}
 		}];
 	}
@@ -135,7 +136,7 @@ module.exports = class SQSHelper {
 		eventProperties
 	}, {
 		mainConsumer,
-		delayedConsumer
+		delayConsumer
 	}) {
 
 		let { filename, titleName: functionName } = this.names;
@@ -146,11 +147,11 @@ module.exports = class SQSHelper {
 		if(mainConsumer) {
 			queueArn = this.arns.mainQueue;
 			dependsOn = this.names.mainQueue;
-		} else if(delayedConsumer) {
-			queueArn = this.arns.delayedQueue;
-			dependsOn = this.names.delayedQueue;
-			functionName = `${functionName}Delayed`;
-			filename = `${filename}-delayed`;
+		} else if(delayConsumer) {
+			queueArn = this.arns.delayQueue;
+			dependsOn = this.names.delayQueue;
+			functionName = `${functionName}Delay`;
+			filename = `${filename}-delay`;
 		} else {
 			// dlq consumer
 			queueArn = this.arns.dlq;
@@ -173,7 +174,7 @@ module.exports = class SQSHelper {
 			},
 			events: [
 				this.createEventSource(queueArn, { batchSize, maximumBatchingWindow, eventProperties }),
-				...mainConsumer && this.delayedConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.delayedQueue, this.delayedConsumerProperties)] : [],
+				...mainConsumer && this.delayConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.delayQueue, this.delayConsumerProperties)] : [],
 				...mainConsumer && this.dlqConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.dlq, this.dlqConsumerProperties)] : []
 			],
 			...functionProperties
@@ -201,15 +202,17 @@ module.exports = class SQSHelper {
 		receiveMessageWaitTimeSeconds,
 		visibilityTimeout,
 		messageRetentionPeriod,
+		delaySeconds,
 		fifoQueue,
 		fifoThroughputLimit,
 		contentBasedDeduplication,
 		deduplicationScope,
+		addTags,
 		...extraProperties
 	}, {
 		mainQueue,
 		dlq,
-		delayedQueue
+		delayQueue
 	}) {
 
 		let name;
@@ -218,10 +221,10 @@ module.exports = class SQSHelper {
 
 		if(mainQueue) {
 			name = this.names.mainQueue;
-			deadLetterTargetArn = this.useDelayedQueue ? this.arns.delayedQueue : this.arns.dlq;
-			dependsOn = this.useDelayedQueue ? this.names.delayedQueue : this.names.dlq;
-		} else if(delayedQueue) {
-			name = this.names.delayedQueue;
+			deadLetterTargetArn = this.useDelayQueue ? this.arns.delayQueue : this.arns.dlq;
+			dependsOn = this.useDelayQueue ? this.names.delayQueue : this.names.dlq;
+		} else if(delayQueue) {
+			name = this.names.delayQueue;
 			deadLetterTargetArn = this.arns.dlq;
 			dependsOn = this.names.dlq;
 		} else {
@@ -242,6 +245,7 @@ module.exports = class SQSHelper {
 						RedrivePolicy: JSON.stringify({ maxReceiveCount, deadLetterTargetArn })
 					},
 					...messageRetentionPeriod && { MessageRetentionPeriod: messageRetentionPeriod },
+					...delaySeconds && { DelaySeconds: delaySeconds },
 					...this.fifoQueue && { FifoQueue: true },
 					...this.fifoQueue && fifoThroughputLimit && { FifoThroughputLimit: fifoThroughputLimit },
 					...this.fifoQueue && deduplicationScope && { DeduplicationScope: deduplicationScope },
@@ -250,7 +254,8 @@ module.exports = class SQSHelper {
 						...defaultTags,
 						{ Key: 'SQSConstruct', Value: this.names.titleName },
 						...dlq ? [{ Key: 'IsDLQ', Value: 'true' }] : [],
-						...delayedQueue ? [{ Key: 'DelayedQueue', Value: 'true' }] : []
+						...delayQueue ? [{ Key: 'DelayQueue', Value: 'true' }] : [],
+						...addTags || []
 					],
 					...extraProperties
 				},

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -38,8 +38,6 @@ module.exports = class SQSHelper {
 
 		this.setConfigsWithDefaults(userConfigs);
 
-		console.log(this.buildConsumerFunction(this.consumerProperties, { mainConsumer: true }));
-
 		return [
 
 			this.getSQSUrlEnvVars(),

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -14,7 +14,7 @@ const {
 } = require('./helper/default');
 
 const { defaultTags } = require('../utils/default-tags');
-const addFifoSuffix = require('./helper/add-fifo-suffix');
+const fixFifoName = require('./helper/fix-fifo-name');
 const generateArns = require('./helper/generate-arns');
 
 module.exports = class SQSHelper {
@@ -32,11 +32,23 @@ module.exports = class SQSHelper {
 		}];
 	}
 
-	static buildHooks(userConfigs = {}) {
+	static buildHooks(configs = {}) {
 
-		this.validateConfigs(userConfigs);
+		this.validateConfigs(configs);
 
-		this.setConfigsWithDefaults(userConfigs);
+		this.setConfigsWithDefaults(configs);
+
+		const delayedHooks = [];
+
+		if(this.useDelayedQueue) {
+
+			// is used this.delayedConsumerProperties cause must have a consumer (the own consumer or the main consumer)
+			// this.delayedConsumerProperties has default mainConsumer configs
+			if(this.shouldAddConsumer(this.delayedConsumerProperties))
+				delayedHooks.push(this.buildConsumerFunction(this.delayedConsumerProperties, { delayedConsumer: true }));
+
+			delayedHooks.push(this.buildQueueResource(this.delayedQueueProperties, { delayedQueue: true }));
+		}
 
 		return [
 
@@ -44,34 +56,30 @@ module.exports = class SQSHelper {
 
 			this.buildConsumerFunction(this.consumerProperties, { mainConsumer: true }),
 
-			this.buildQueueResource(this.mainQueueProperties),
+			this.buildQueueResource(this.mainQueueProperties, { mainQueue: true }),
+
+			...delayedHooks,
 
 			this.buildQueueResource(this.dlqQueueProperties, { dlq: true }),
 
-			...this.shouldAddConsumer(userConfigs.dlqConsumerProperties)
+			...this.shouldAddConsumer(configs.dlqConsumerProperties)
 				? [this.buildConsumerFunction(this.dlqConsumerProperties, { dlqConsumer: true })]
-				: [],
-
-			...this.shouldAddConsumer(userConfigs.delayedConsumerProperties)
-				? [
-					this.buildConsumerFunction(this.delayedConsumerProperties, { delayedConsumer: true }),
-					this.buildQueueResource(this.delayedQueueProperties, { delayedQueue: true })
-				] : []
+				: []
 		];
 	}
 
-	static validateConfigs(userConfigs) {
+	static validateConfigs(configs) {
 
-		if(!userConfigs.name?.length)
+		if(!configs.name?.length)
 			throw new Error('Missing or empty name hook configuration in SQS helper');
 
 		[
-			['Main Consumer', userConfigs.consumerProperties],
-			['Main Queue', userConfigs.mainQueueProperties],
-			['Delayed Consumer', userConfigs.delayedConsumerProperties],
-			['Delayed Queue', userConfigs.delayedQueueProperties],
-			['DLQ Consumer', userConfigs.dlqConsumerProperties],
-			['DLQ Queue', userConfigs.dlqQueueProperties]
+			['Main Consumer', configs.consumerProperties],
+			['Main Queue', configs.mainQueueProperties],
+			['Delayed Consumer', configs.delayedConsumerProperties],
+			['Delayed Queue', configs.delayedQueueProperties],
+			['DLQ Consumer', configs.dlqConsumerProperties],
+			['DLQ Queue', configs.dlqQueueProperties]
 		].forEach(([type, properties]) => {
 			if(properties && (typeof properties !== 'object' || Array.isArray(properties)))
 				throw new Error(`${type} Properties must be an Object with configuration in SQS helper`);
@@ -83,6 +91,7 @@ module.exports = class SQSHelper {
 		this.consumerProperties = { ...consumerDefaultsValue, ...userConfigs.consumerProperties };
 		this.mainQueueProperties = { ...mainQueueDefaultsValue, ...userConfigs.mainQueueProperties };
 
+		// delayed queue and consumer uses main config by default
 		this.delayedConsumerProperties = { ...consumerDefaultsValue, ...userConfigs.delayedConsumerProperties };
 		this.delayedQueueProperties = { ...mainQueueDefaultsValue, ...userConfigs.delayedQueueProperties };
 
@@ -105,11 +114,11 @@ module.exports = class SQSHelper {
 
 	static getSQSUrlEnvVars() {
 		return ['envVars', {
-			[`${this.names.envVarName}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(this.names.mainQueue) : this.names.mainQueue}`,
-			[`${this.names.envVarName}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(this.names.dlq) : this.names.dlq}`,
+			[`${this.names.envVarName}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.mainQueue, this.fifoQueue)}`,
+			[`${this.names.envVarName}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.dlq, this.fifoQueue)}`,
 
 			...this.useDelayedQueue && {
-				[`${this.names.envVarName}_DELAYED_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(this.names.delayedQueue) : this.names.delayedQueue}`
+				[`${this.names.envVarName}_DELAYED_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.delayedQueue, this.fifoQueue)}`
 			}
 		}];
 	}
@@ -126,21 +135,24 @@ module.exports = class SQSHelper {
 		eventProperties
 	}, {
 		mainConsumer,
-		dlqConsumer,
 		delayedConsumer
 	}) {
 
 		let { filename, titleName: functionName } = this.names;
 
-		let queueArn = this.arns.mainQueue;
-		let dependsOn = this.names.mainQueue;
+		let queueArn;
+		let dependsOn;
 
-		if(delayedConsumer) {
+		if(mainConsumer) {
+			queueArn = this.arns.mainQueue;
+			dependsOn = this.names.mainQueue;
+		} else if(delayedConsumer) {
 			queueArn = this.arns.delayedQueue;
 			dependsOn = this.names.delayedQueue;
 			functionName = `${functionName}Delayed`;
 			filename = `${filename}-delayed`;
-		} else if(dlqConsumer) {
+		} else {
+			// dlq consumer
 			queueArn = this.arns.dlq;
 			dependsOn = this.names.dlq;
 			functionName = `${functionName}DLQ`;
@@ -195,28 +207,26 @@ module.exports = class SQSHelper {
 		deduplicationScope,
 		...extraProperties
 	}, {
+		mainQueue,
 		dlq,
 		delayedQueue
-	} = {}) {
+	}) {
 
-		let name = this.names.mainQueue;
-
+		let name;
 		let deadLetterTargetArn;
 		let dependsOn;
 
-		if(delayedQueue) {
-			name = this.names.delayedQueue;
-
-			deadLetterTargetArn = this.arns.dlq;
-
-		} else if(dlq)
-			name = this.names.dlq;
-
-		else {
-			// main queue
-
+		if(mainQueue) {
+			name = this.names.mainQueue;
 			deadLetterTargetArn = this.useDelayedQueue ? this.arns.delayedQueue : this.arns.dlq;
 			dependsOn = this.useDelayedQueue ? this.names.delayedQueue : this.names.dlq;
+		} else if(delayedQueue) {
+			name = this.names.delayedQueue;
+			deadLetterTargetArn = this.arns.dlq;
+			dependsOn = this.names.dlq;
+		} else {
+			// dlq
+			name = this.names.dlq;
 		}
 
 		return ['resource', {
@@ -224,7 +234,7 @@ module.exports = class SQSHelper {
 			resource: {
 				Type: 'AWS::SQS::Queue',
 				Properties: {
-					QueueName: `\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(name) : name}`,
+					QueueName: `\${self:custom.serviceName}${fixFifoName(name, this.fifoQueue)}`,
 					ReceiveMessageWaitTimeSeconds: receiveMessageWaitTimeSeconds,
 					VisibilityTimeout: visibilityTimeout,
 					// eslint-disable-next-line max-len

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+
 'use strict';
 
 const generateQueueNames = require('./helper/generate-names');
@@ -30,142 +32,119 @@ module.exports = class SQSHelper {
 		}];
 	}
 
-	static buildHooks(configs = {}) {
+	static buildHooks(userConfigs = {}) {
 
-		this.validateConfigs(configs);
+		this.validateConfigs(userConfigs);
 
-		const {
-			name,
-			consumerProperties,
-			mainQueueProperties,
-			dlqQueueProperties,
-			dlqConsumerProperties
-		} = this.getConfigsProperties(configs);
+		this.setConfigsWithDefaults(userConfigs);
 
-		const fifoQueue = !!mainQueueProperties.fifoQueue;
-
-		const {
-			titleName,
-			sqsName,
-			dlqName,
-			filename,
-			envVarName
-		} = generateQueueNames(name);
-
-		const {
-			sqsArn, dlqArn
-		} = generateArns(sqsName, dlqName, fifoQueue);
+		console.log(this.buildConsumerFunction(this.consumerProperties, { mainConsumer: true }));
 
 		return [
 
-			this.getSQSUrlEnvVars(envVarName, sqsName, dlqName, fifoQueue),
+			this.getSQSUrlEnvVars(),
 
-			this.buildConsumerFunction(titleName, {
-				...consumerProperties,
-				filename,
-				queueName: sqsName,
-				queueArn: sqsArn,
-				fifoQueue
-			}),
+			this.buildConsumerFunction(this.consumerProperties, { mainConsumer: true }),
 
-			this.buildQueueResource(sqsName, {
-				...mainQueueProperties,
-				titleName,
-				dlqName,
-				dlqArn,
-				fifoQueue
-			}),
+			this.buildQueueResource(this.mainQueueProperties),
 
-			this.buildQueueResource(dlqName, {
-				...dlqQueueProperties,
-				titleName,
-				isDLQ: true,
-				fifoQueue
-			}),
+			this.buildQueueResource(this.dlqQueueProperties, { dlq: true }),
 
-			...configs.dlqConsumerProperties && Object.keys(configs.dlqConsumerProperties).length
-				? [this.buildConsumerFunction(titleName, {
-					...dlqConsumerProperties,
-					filename,
-					queueName: dlqName,
-					queueArn: dlqArn,
-					isDLQ: true,
-					fifoQueue
-				})] : []
+			...this.shouldAddConsumer(userConfigs.dlqConsumerProperties)
+				? [this.buildConsumerFunction(this.dlqConsumerProperties, { dlqConsumer: true })]
+				: [],
+
+			...this.shouldAddConsumer(userConfigs.delayedConsumerProperties)
+				? [
+					this.buildConsumerFunction(this.delayedConsumerProperties, { delayedConsumer: true }),
+					this.buildQueueResource(this.delayedQueueProperties, { delayedQueue: true })
+				] : []
 		];
 	}
 
-	static validateConfigs(configs) {
+	static validateConfigs(userConfigs) {
 
-		if(!configs.name?.length)
+		if(!userConfigs.name?.length)
 			throw new Error('Missing or empty name hook configuration in SQS helper');
 
 		[
-			['Main Consumer', configs.consumerProperties],
-			['Main Queue', configs.mainQueueProperties],
-			['DLQ Consumer', configs.dlqConsumerProperties],
-			['DLQ Queue', configs.dlqQueueProperties]
+			['Main Consumer', userConfigs.consumerProperties],
+			['Main Queue', userConfigs.mainQueueProperties],
+			['Delayed Consumer', userConfigs.delayedConsumerProperties],
+			['Delayed Queue', userConfigs.delayedQueueProperties],
+			['DLQ Consumer', userConfigs.dlqConsumerProperties],
+			['DLQ Queue', userConfigs.dlqQueueProperties]
 		].forEach(([type, properties]) => {
 			if(properties && (typeof properties !== 'object' || Array.isArray(properties)))
 				throw new Error(`${type} Properties must be an Object with configuration in SQS helper`);
 		});
 	}
 
-	static getConfigsProperties(configs) {
+	static setConfigsWithDefaults(userConfigs) {
 
-		const consumerProperties = {
-			...consumerDefaultsValue,
-			...configs.consumerProperties
-		};
+		this.consumerProperties = { ...consumerDefaultsValue, ...userConfigs.consumerProperties };
+		this.mainQueueProperties = { ...mainQueueDefaultsValue, ...userConfigs.mainQueueProperties };
 
-		const mainQueueProperties = {
-			...mainQueueDefaultsValue,
-			...configs.mainQueueProperties
-		};
+		this.delayedConsumerProperties = { ...consumerDefaultsValue, ...userConfigs.delayedConsumerProperties };
+		this.delayedQueueProperties = { ...mainQueueDefaultsValue, ...userConfigs.delayedQueueProperties };
 
-		const dlqConsumerProperties = {
-			...dlqConsumerDefaultsValue,
-			...configs.dlqConsumerProperties
-		};
+		this.dlqConsumerProperties = { ...dlqConsumerDefaultsValue, ...userConfigs.dlqConsumerProperties };
+		this.dlqQueueProperties = { ...dlqQueueDefaultsValue, ...userConfigs.dlqQueueProperties };
 
-		const dlqQueueProperties = {
-			...dlqQueueDefaultsValue,
-			...configs.dlqQueueProperties
-		};
+		this.fifoQueue = !!userConfigs.mainQueueProperties?.fifoQueue;
+		this.useDelayedQueue = !!userConfigs.delayedQueueProperties;
 
-		return {
-			name: configs.name,
-			consumerProperties,
-			mainQueueProperties,
-			dlqQueueProperties,
-			dlqConsumerProperties
-		};
+		this.names = generateQueueNames(userConfigs.name);
+
+		this.arns = generateArns(this.names, this.fifoQueue);
 	}
 
-	static getSQSUrlEnvVars(name, sqsName, dlqName, fifoQueue) {
+	static shouldAddConsumer(consumerProperties) {
+		return consumerProperties
+			&& Object.keys(consumerProperties).length
+			&& !consumerProperties.useMainHandler;
+	}
+
+	static getSQSUrlEnvVars() {
 		return ['envVars', {
-			[`${name}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(sqsName) : sqsName}`,
-			[`${name}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(dlqName) : dlqName}`
+			[`${this.names.envVarName}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(this.names.mainQueue) : this.names.mainQueue}`,
+			[`${this.names.envVarName}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(this.names.dlq) : this.names.dlq}`,
+
+			...this.useDelayedQueue && {
+				[`${this.names.envVarName}_DELAYED_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(this.names.delayedQueue) : this.names.delayedQueue}`
+			}
 		}];
 	}
 
-	static buildConsumerFunction(functionName, {
-		isDLQ,
-		prefixPath,
-		filename,
-		handler,
+	static buildConsumerFunction({
 		timeout,
-		queueName,
-		queueArn,
+		handler,
 		description,
+		maximumBatchingWindow,
+		batchSize,
+		prefixPath,
 		functionProperties,
 		rawProperties,
-		batchSize,
-		maximumBatchingWindow,
 		eventProperties
+	}, {
+		mainConsumer,
+		dlqConsumer,
+		delayedConsumer
 	}) {
 
-		if(isDLQ) {
+		let { filename, titleName: functionName } = this.names;
+
+		let queueArn = this.arns.mainQueue;
+		let dependsOn = this.names.mainQueue;
+
+		if(delayedConsumer) {
+			queueArn = this.arns.delayedQueue;
+			dependsOn = this.names.delayedQueue;
+			functionName = `${functionName}Delayed`;
+			filename = `${filename}-delayed`;
+		} else if(dlqConsumer) {
+			queueArn = this.arns.dlq;
+			dependsOn = this.names.dlq;
 			functionName = `${functionName}DLQ`;
 			filename = `${filename}-dlq`;
 		}
@@ -179,30 +158,36 @@ module.exports = class SQSHelper {
 			description: description || `${functionName} SQS Queue Consumer`,
 			timeout,
 			rawProperties: {
-				dependsOn: [queueName],
+				dependsOn: [dependsOn],
 				...rawProperties
 			},
 			events: [
-				{
-					sqs: {
-						arn: queueArn,
-						functionResponseType: 'ReportBatchItemFailures',
-						...batchSize && { batchSize },
-						...maximumBatchingWindow && { maximumBatchingWindow },
-						...eventProperties
-					}
-				}
+				this.createEventSource(queueArn, { batchSize, maximumBatchingWindow, eventProperties }),
+				...mainConsumer && this.delayedConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.delayedQueue, this.delayedConsumerProperties)] : [],
+				...mainConsumer && this.dlqConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.dlq, this.dlqConsumerProperties)] : []
 			],
 			...functionProperties
 		}];
 	}
 
-	static buildQueueResource(name, {
-		isDLQ,
-		titleName,
+	static createEventSource(arn, {
+		batchSize,
+		maximumBatchingWindow,
+		eventProperties
+	}) {
+		return {
+			sqs: {
+				arn,
+				functionResponseType: 'ReportBatchItemFailures',
+				...batchSize && { batchSize },
+				...maximumBatchingWindow && { maximumBatchingWindow },
+				...eventProperties
+			}
+		};
+	}
+
+	static buildQueueResource({
 		maxReceiveCount,
-		dlqName,
-		dlqArn,
 		receiveMessageWaitTimeSeconds,
 		visibilityTimeout,
 		messageRetentionPeriod,
@@ -211,36 +196,57 @@ module.exports = class SQSHelper {
 		contentBasedDeduplication,
 		deduplicationScope,
 		...extraProperties
-	}) {
+	}, {
+		dlq,
+		delayedQueue
+	} = {}) {
+
+		let name = this.names.mainQueue;
+
+		let deadLetterTargetArn;
+		let dependsOn;
+
+		if(delayedQueue) {
+			name = this.names.delayedQueue;
+
+			deadLetterTargetArn = this.arns.dlq;
+
+		} else if(dlq)
+			name = this.names.dlq;
+
+		else {
+			// main queue
+
+			deadLetterTargetArn = this.useDelayedQueue ? this.arns.delayedQueue : this.arns.dlq;
+			dependsOn = this.useDelayedQueue ? this.names.delayedQueue : this.names.dlq;
+		}
 
 		return ['resource', {
 			name,
 			resource: {
 				Type: 'AWS::SQS::Queue',
 				Properties: {
-					QueueName: `\${self:custom.serviceName}${fifoQueue ? addFifoSuffix(name) : name}`,
+					QueueName: `\${self:custom.serviceName}${this.fifoQueue ? addFifoSuffix(name) : name}`,
 					ReceiveMessageWaitTimeSeconds: receiveMessageWaitTimeSeconds,
 					VisibilityTimeout: visibilityTimeout,
 					// eslint-disable-next-line max-len
-					...dlqName && {
-						RedrivePolicy: JSON.stringify({
-							maxReceiveCount,
-							deadLetterTargetArn: dlqArn
-						})
+					...deadLetterTargetArn && {
+						RedrivePolicy: JSON.stringify({ maxReceiveCount, deadLetterTargetArn })
 					},
 					...messageRetentionPeriod && { MessageRetentionPeriod: messageRetentionPeriod },
-					...fifoQueue && { FifoQueue: true },
-					...fifoQueue && fifoThroughputLimit && { FifoThroughputLimit: fifoThroughputLimit },
-					...fifoQueue && deduplicationScope && { DeduplicationScope: deduplicationScope },
-					...fifoQueue && contentBasedDeduplication && { ContentBasedDeduplication: true },
+					...this.fifoQueue && { FifoQueue: true },
+					...this.fifoQueue && fifoThroughputLimit && { FifoThroughputLimit: fifoThroughputLimit },
+					...this.fifoQueue && deduplicationScope && { DeduplicationScope: deduplicationScope },
+					...this.fifoQueue && contentBasedDeduplication && { ContentBasedDeduplication: true },
 					Tags: [
 						...defaultTags,
-						{ Key: 'SQSConstruct', Value: titleName },
-						...isDLQ ? [{ Key: 'IsDLQ', Value: 'true' }] : []
+						{ Key: 'SQSConstruct', Value: this.names.titleName },
+						...dlq ? [{ Key: 'IsDLQ', Value: 'true' }] : [],
+						...delayedQueue ? [{ Key: 'DelayedQueue', Value: 'true' }] : []
 					],
 					...extraProperties
 				},
-				...dlqName && { DependsOn: [dlqName] }
+				...dependsOn && { DependsOn: [dependsOn] }
 			}
 		}];
 	}


### PR DESCRIPTION
Se sumó la posibilidad de tener una DelayQueue "intermedia" entre la Main y la DLQ.
Cuando se envía `delayQueueProperties` se suma la queue y consumer automáticamente.

Al sumar la Delay Queue cambia el RedrivePolicy de la siguiente forma
- La **Main Queue** tiene como DLQ a la **Delay Queue**
- La **Delay Queue** tiene como DLQ a la **DLQ**
- La **DLQ** sigue sin tener RedrivePolicy ✅ 

ℹ️ El consumer de las delay queues es requerido como pasa con la main queue para procesar si o si los mensajes. Se puede enviar `useMainHandler` en `delayConsumerProperties` para usar el mismo handler de la main queue y así no tener otra función especial cuando va a ser todo igual solo que "más lento" o con distintos baches.

ℹ️ Hice que los _defaults_ de la Delay Queue y Delay Consumer sean los mismos que los de la Main Queue y Main Consumer. Salvo por el `delaySeconds` que por default es **300** para la DelayQueue

ℹ️ También le puse una tag especial a las Delayed Queues `DelayQueue: true`, me pareció util para diferenciarlas

ℹ️ Se sumó la posibilidad de configurar `DelaySeconds` en las Queues.

🆕 📣  Sumé el campo `addTags` para poder tener custom Tag en las Queues  📣 🆕