### PR TITLE
Sumar configuracion de variables de entorno

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ You can use `SQSHelper.buildHooks(configs)` method. This will create an _array_ 
 
 **Parameters**
 - `configs`: _Object_
-	- `name`: **REQUIRED** | _String_ | The name of SQS, it will be uses for every resource. It must be not empty and _camelCase_ to avoid issues creating the resources names.
+	- `name`: **REQUIRED** | _String_ | The name of SQS, it will be used for every resource. It must be not empty and _camelCase_ to avoid issues creating the resources names.
 	- `mainQueueProperties`: **OPTIONAL** _Object_ | If it is not passed, it will use _default_ data.
 	- `consumerProperties`: **OPTIONAL** | _Object_ | If it is not passed, it will use _default_ data.
 	- `delayConsumerProperties`: **OPTIONAL** | _Object_ | If it is not passed, it will use _default_ data when `delayQueueProperties` received.
@@ -362,7 +362,8 @@ All `mainQueueProperties`, `delayQueueProperties` and `dlqQueueProperties` field
 - `visibilityTimeout`: _default_: 60 (MainQueue and DelayQueue) or 20 (DLQ).
 - `messageRetentionPeriod`: _default_: 864000 (only for DLQ).
 - `delaySeconds`: _default_: 300 (only for DelayQueue).
-- `addTags`: _object array_: To add Tags for queues. The AWS tag format is `[{ Key: 'myTag', Value: 'theTagValue' }]`
+- `addTags`: _object array_: To add Tags for queues. The AWS tag format is `[{ Key: 'myTag', Value: 'theTagValue' }]`.
+- `generateEnvVars`: _boolean_ | If set to true, the environment variables with the SQS url will be generated. The default will be `true` only for SQS queues.
 
 FIFO properties (since _9.6.0_)
 - `fifoQueue`: _boolean_ | If set to `true`, creates a FIFO queue.
@@ -388,7 +389,7 @@ If `prefixPath` received the location will be
 
 #### SQS URL Env Vars
 
-Environment Variables will be created for SQS URLs:
+Environment Variables will be created for SQS URL if the property `generateEnvVars` of each queue is set as true (for main queues, `generateEnvVars` defaults to `true`):
 
 * `[NAME_IN_SNAKE_CASE]_SQS_QUEUE_URL` for main queue
 * `[NAME_IN_SNAKE_CASE]_DELAY_QUEUE_URL` for delay queue (when `delayQueueProperties` received)

--- a/lib/sqs-helper/helper/default.js
+++ b/lib/sqs-helper/helper/default.js
@@ -19,13 +19,15 @@ const mainQueueDefaultsValue = {
 	// To allow your function time to process each batch of records, set the source queue's visibility timeout to at least six times
 	// the timeout that you configure on your function.
 	// The extra time allows for Lambda to retry if your function is throttled while processing a previous batch.
-	visibilityTimeout: 90
+	visibilityTimeout: 90,
+	generateEnvVars: true
 };
 
 const delayQueueDefaultsValue = {
 	...mainQueueDefaultsValue,
 	// The time in seconds for which the delivery of all messages in the queue is delayed. You can specify an integer value of 0 to 900 (15 minutes).
-	delaySeconds: 300
+	delaySeconds: 300,
+	generateEnvVars: false
 };
 
 const dlqConsumerDefaultsValue = {
@@ -38,7 +40,8 @@ const dlqQueueDefaultsValue = {
 	// Hide a message for 1:30 minutes after sending it to a consumer before showing it back
 	visibilityTimeout: 90,
 	// Keep a message in the DLQ for 10 days before deleting it
-	messageRetentionPeriod: 864000
+	messageRetentionPeriod: 864000,
+	generateEnvVars: false
 };
 
 module.exports = {

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -53,7 +53,7 @@ module.exports = class SQSHelper {
 
 		return [
 
-			this.getSQSUrlEnvVars(),
+			...this.getSQSUrlEnvVars(),
 
 			this.buildConsumerFunction(this.consumerProperties, { mainConsumer: true }),
 
@@ -114,14 +114,24 @@ module.exports = class SQSHelper {
 	}
 
 	static getSQSUrlEnvVars() {
-		return ['envVars', {
-			[`${this.names.envVarName}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.mainQueue, this.fifoQueue)}`,
-			[`${this.names.envVarName}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.dlq, this.fifoQueue)}`,
 
-			...this.useDelayQueue && {
-				[`${this.names.envVarName}_DELAY_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.delayQueue, this.fifoQueue)}`
-			}
-		}];
+		const shouldGenerateEnvVars = this.mainQueueProperties.generateEnvVars ||
+			this.dlqQueueProperties.generateEnvVars ||
+			this.delayQueueProperties.generateEnvVars;
+
+		if(!shouldGenerateEnvVars)
+			return [];
+
+		return [
+			['envVars', {
+				...this.mainQueueProperties.generateEnvVars && { [`${this.names.envVarName}_SQS_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.mainQueue, this.fifoQueue)}` },
+				...this.dlqQueueProperties.generateEnvVars && { [`${this.names.envVarName}_DLQ_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.dlq, this.fifoQueue)}` },
+
+				...this.delayQueueProperties.generateEnvVars && {
+					[`${this.names.envVarName}_DELAY_QUEUE_URL`]: `${baseUrl}\${self:custom.serviceName}${fixFifoName(this.names.delayQueue, this.fifoQueue)}`
+				}
+			}]
+		];
 	}
 
 	static buildConsumerFunction({
@@ -208,6 +218,7 @@ module.exports = class SQSHelper {
 		contentBasedDeduplication,
 		deduplicationScope,
 		addTags,
+		generateEnvVars,
 		...extraProperties
 	}, {
 		mainQueue,


### PR DESCRIPTION
## LINK AL TICKET
[Historia](https://janiscommerce.atlassian.net/browse/JCN-492) | [Subtarea](https://janiscommerce.atlassian.net/browse/JCN-493)

## DESCRIPCIÓN DEL REQUERIMIENTO
Al momento de crear SQSs utilizando  https://www.npmjs.com/package/sls-helper-plugin-janis#sqs-helper se generan de forma automatica variables de entorno que contienen las urls de las colas, esto incluye al SQS/ propiamente dicho, DLQ. El problema que estamos teniendo es que al crear un SQS, dentro estamos generando variables de entorno para el SQS y sus respectivas DLQ. De estas variables de entorno, las unicas que se utilizan realmente son las de los SQS, lo que genera que tengamos n variables innecesarias que hacen que nos acerquemos al limite de 4kb que establece Amazon. 

### Solución

Modificar el paquete https://www.npmjs.com/package/sls-helper-plugin-janis#sqs-helperpara sumar la posibilidad de configurar si un recurso de SQS debe o no generar variables de entorno (generateEnvVars). La idea es que por default solo los SQSs guarden su url

## DESCRIPCIÓN DE LA SOLUCIÓN
Se sumo para todos los tipos de SQS (main, DLQ y delay) la nueva propiedad generateEnvVars para poder definir si se deben crear las variables de entorno.
Por default sera `true` unicamente para las main, ya que son las unicas variables de entorno que efectivamente se estan usando en algun lado. 

## Ejemplo de uso

```

const { SQSHelper } = require('sls-helper-plugin-janis');

module.exports = SQSHelper.buildHooks({
	name: 'randomSQS',
	dlqQueueProperties: {
		generateEnvVars: true
	}
});
