### PR TITLE
Added new default Policy to base hook to use ssm:GetParameter

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,8 @@ jobs:
         run: npm run test
       - name: Lint code
         run: npm run lint
-      - run: npm publish --access public
+      - run: |
+          TAG=$(echo $GITHUB_REF_NAME | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
+          npm publish --tag ${TAG:-latest} --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+            NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,4 +28,4 @@ jobs:
           TAG=$(echo $GITHUB_REF_NAME | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
           npm publish --tag ${TAG:-latest} --access public
         env:
-            NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/lib/service/base.js
+++ b/lib/service/base.js
@@ -333,6 +333,31 @@ module.exports = ({
 										}
 									]
 								}
+							},
+							{
+								PolicyName: 'janis-${self:custom.serviceCode}-get-databases-parameter-store',
+								PolicyDocument: {
+									Version: '2012-10-17',
+									Statement: [
+										{
+											Effect: 'Allow',
+											Action: 'ssm:GetParameter',
+											Resource: [
+												{
+													'Fn::Join': [
+														':',
+														[
+															'arn:aws:ssm',
+															{ Ref: 'AWS::Region' },
+															{ Ref: 'AWS::AccountId' },
+															'parameter/${self:custom.serviceCode}-databases'
+														]
+													]
+												}
+											]
+										}
+									]
+								}
 							}
 						]
 					}

--- a/tests/unit/hooks/base.js
+++ b/tests/unit/hooks/base.js
@@ -296,6 +296,31 @@ describe('Hooks', () => {
 											}
 										]
 									}
+								},
+								{
+									PolicyName: 'janis-${self:custom.serviceCode}-get-databases-parameter-store',
+									PolicyDocument: {
+										Version: '2012-10-17',
+										Statement: [
+											{
+												Effect: 'Allow',
+												Action: 'ssm:GetParameter',
+												Resource: [
+													{
+														'Fn::Join': [
+															':',
+															[
+																'arn:aws:ssm',
+																{ Ref: 'AWS::Region' },
+																{ Ref: 'AWS::AccountId' },
+																'parameter/${self:custom.serviceCode}-databases'
+															]
+														]
+													}
+												]
+											}
+										]
+									}
 								}
 							]
 						}


### PR DESCRIPTION
Se agregó una nueva policy default `janis-${self:custom.serviceCode}-get-databases-parameter-store` para que los MS puedan hacer GetParameter del recurso especifico que va a setear DevOps `{serviceCode}-databases`