### PR TITLE
Opción para usar el ParameterStore  accountsIdsByService de manera "local" para las cuentas que sean dueñas del Parametro

### DIFF
--- a/lib/service/base.js
+++ b/lib/service/base.js
@@ -103,8 +103,6 @@ module.exports = async ({
 	if(!servicePort || typeof servicePort !== 'number')
 		throw new Error(`Missing or invalid servicePort in janis.base hook: ${inspect(servicePort)}`);
 
-	console.log({ custom });
-
 	const awsAccountsByService = custom?.localAccountsIdsByService
 		? await ParameterStore.getParameter('accountsIdsByService')
 		: await ParameterStore.getSharedParameter('accountsIdsByService');

--- a/lib/service/base.js
+++ b/lib/service/base.js
@@ -103,7 +103,11 @@ module.exports = async ({
 	if(!servicePort || typeof servicePort !== 'number')
 		throw new Error(`Missing or invalid servicePort in janis.base hook: ${inspect(servicePort)}`);
 
-	const awsAccountsByService = await ParameterStore.getSharedParameter('accountsIdsByService');
+	console.log({ custom });
+
+	const awsAccountsByService = custom?.localAccountsIdsByService
+		? await ParameterStore.getParameter('accountsIdsByService')
+		: await ParameterStore.getSharedParameter('accountsIdsByService');
 
 	const serviceTitle = titleCase(serviceCode);
 	const serviceName = serviceTitle.replace(/ /g, '');

--- a/lib/utils/parameter-store.js
+++ b/lib/utils/parameter-store.js
@@ -43,3 +43,5 @@ module.exports.getSharedParameter = async parameterName => {
 
 	return parametersCache[parameterName];
 };
+
+module.exports.getParameter = getParameter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "serverless": "^3.30.1",
-        "sls-helper": ">= 1.9.0"
+        "sls-helper": ">= 1.15.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/tests/unit/hooks/base.js
+++ b/tests/unit/hooks/base.js
@@ -21,6 +21,7 @@ describe('Hooks', () => {
 
 		beforeEach(() => {
 			sinon.stub(ParameterStore, 'getSharedParameter').resolves(accountIdsParameterValue);
+			sinon.stub(ParameterStore, 'getParameter').resolves(accountIdsParameterValue);
 		});
 
 		afterEach(() => {
@@ -507,6 +508,9 @@ describe('Hooks', () => {
 			});
 
 			assert.deepStrictEqual(serviceConfig, expectedConfig);
+
+			sinon.assert.calledOnceWithExactly(ParameterStore.getSharedParameter, 'accountsIdsByService');
+			sinon.assert.notCalled(ParameterStore.getParameter);
 		});
 
 		it('Should not override the original configuration', async () => {
@@ -664,6 +668,25 @@ describe('Hooks', () => {
 
 			assert.deepStrictEqual(serviceConfig, clonedExpectedConfig);
 		});
+
+		it('Should use local ParameterStore accountsIdsByService when received custom.localAccountsIdsByService', async () => {
+
+			const serviceConfig = await base({
+				custom: { localAccountsIdsByService: true }
+			}, {
+				serviceCode: validServiceCode,
+				servicePort: validServicePort
+			});
+
+			const expectedConfigForLocalParameter = JSON.parse(JSON.stringify(expectedConfig));
+			expectedConfigForLocalParameter.custom.localAccountsIdsByService = true;
+
+			assert.deepStrictEqual(serviceConfig, expectedConfigForLocalParameter);
+
+			sinon.assert.notCalled(ParameterStore.getSharedParameter);
+			sinon.assert.calledOnceWithExactly(ParameterStore.getParameter, 'accountsIdsByService');
+		});
+
 	});
 
 });


### PR DESCRIPTION
Se sumó la opción `custom.localAccountsIdsByService` para buscar de manera "local" el parámetro en ParameterStore.
Esto es necesario para cuentas que sean las dueñas del parámetro.