### PR TITLE
remote scope is now omitted when generating subscriptions locally

### DIFF
--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -23,6 +23,7 @@ const generateArns = require('./helper/generate-arns');
 const generateSnsArns = require('../sns-helper/helper/generate-arns');
 const { SQSTypes } = require('./helper/sqs-types');
 const { snsTopicScopes } = require('../utils/sns-topic-scopes');
+const { isLocal } = require('../utils/is-local');
 
 module.exports = class SQSHelper {
 
@@ -413,19 +414,21 @@ module.exports = class SQSHelper {
 		if(!this.sourceSnsTopic)
 			return [];
 
-		return this.sourceSnsTopic.map(sourceSnsTopic => ['resource', {
-			name: `SubSNS${sourceSnsTopic.name}SQS${this.names.titleName}`,
-			resource: {
-				Type: 'AWS::SNS::Subscription',
-				Properties: {
-					Protocol: 'sqs',
-					Endpoint: this.arns.mainQueue,
-					RawMessageDelivery: true,
-					TopicArn: generateSnsArns(sourceSnsTopic).topic,
-					...sourceSnsTopic.filterPolicy && { FilterPolicy: sourceSnsTopic.filterPolicy }
-				},
-				DependsOn: [this.names.mainQueue]
-			}
-		}]);
+		return this.sourceSnsTopic
+			.filter(sourceSnsTopic => sourceSnsTopic.scope !== snsTopicScopes.remote || !isLocal())
+			.map(sourceSnsTopic => ['resource', {
+				name: `SubSNS${sourceSnsTopic.name}SQS${this.names.titleName}`,
+				resource: {
+					Type: 'AWS::SNS::Subscription',
+					Properties: {
+						Protocol: 'sqs',
+						Endpoint: this.arns.mainQueue,
+						RawMessageDelivery: true,
+						TopicArn: generateSnsArns(sourceSnsTopic).topic,
+						...sourceSnsTopic.filterPolicy && { FilterPolicy: sourceSnsTopic.filterPolicy }
+					},
+					DependsOn: [this.names.mainQueue]
+				}
+			}]);
 	}
 };

--- a/tests/unit/hook-builder/sqs.js
+++ b/tests/unit/hook-builder/sqs.js
@@ -7,6 +7,12 @@ const { snsTopicScopes } = require('../../../lib/utils/sns-topic-scopes');
 
 describe('Hook Builder Helpers', () => {
 
+	const originalEnvs = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...originalEnvs };
+	});
+
 	describe('SQS', () => {
 
 		context('Get Permission\'s Hook', () => {
@@ -1166,7 +1172,7 @@ describe('Hook Builder Helpers', () => {
 
 			context('SNS Topics from the another account', () => {
 
-				it('Should add a Queue Policy and SNS Subscription to publish messages from the given topic to the main queue', () => {
+				it('Should add a Queue Policy and SNS Subscription to publish messages from the given topic to the main queue (non local env)', () => {
 
 					assert.deepStrictEqual(SQSHelper.buildHooks({
 						name: 'Test',
@@ -1182,6 +1188,26 @@ describe('Hook Builder Helpers', () => {
 						dlqQueueHook(),
 						queuePolicyHook,
 						snsSubscriptionCrossAccountHook
+					]);
+				});
+
+				it('Should add a Queue Policy and omit SNS subscription in local environment', () => {
+
+					process.env.JANIS_LOCAL = '1';
+
+					assert.deepStrictEqual(SQSHelper.buildHooks({
+						name: 'Test',
+						sourceSnsTopic: {
+							scope: snsTopicScopes.remote,
+							serviceCode: 'another-service',
+							name: 'TestTopic'
+						}
+					}), [
+						sqsUrlEnvVarsHook,
+						mainConsumerFunctionHook,
+						mainQueueHook,
+						dlqQueueHook(),
+						queuePolicyHook
 					]);
 				});
 			});


### PR DESCRIPTION
Se ajusto para que cuando existe un SQS con suscripción  a un topic externo este se omita para evitar específicamente problemas en local, la idea es que solo pase esto a nivel local.