### PR TITLE
add default value for maximumConcurrency property in all sqs's

### DIFF
--- a/lib/sqs-helper/helper/default.js
+++ b/lib/sqs-helper/helper/default.js
@@ -4,6 +4,8 @@ const consumerDefaultsValue = {
 	timeout: 15,
 	// Process at most 10 records per lambda invocation
 	batchSize: 10,
+	// Maximum number of concurrent Lambda function invocations allowed for this SQS event source mapping
+	maximumConcurrency: 10,
 	// Query the queue for at most 20 seconds before executing the consumer
 	maximumBatchingWindow: 20
 };
@@ -31,7 +33,9 @@ const delayQueueDefaultsValue = {
 };
 
 const dlqConsumerDefaultsValue = {
-	timeout: 15
+	timeout: 15,
+	// Maximum number of concurrent Lambda function invocations allowed for this SQS event source mapping
+	maximumConcurrency: 10
 };
 
 const dlqQueueDefaultsValue = {

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -212,7 +212,8 @@ module.exports = class SQSHelper {
 		prefixPath,
 		functionProperties,
 		rawProperties,
-		eventProperties
+		eventProperties,
+		maximumConcurrency
 	}, {
 		mainConsumer,
 		delayConsumer
@@ -252,7 +253,7 @@ module.exports = class SQSHelper {
 				...rawProperties
 			},
 			events: [
-				this.createEventSource(queueArn, { batchSize, maximumBatchingWindow, eventProperties }),
+				this.createEventSource(queueArn, { batchSize, maximumBatchingWindow, maximumConcurrency, eventProperties }),
 				...mainConsumer && this.delayConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.delayQueue, this.delayConsumerProperties)] : [],
 				...mainConsumer && this.dlqConsumerProperties?.useMainHandler ? [this.createEventSource(this.arns.dlq, this.dlqConsumerProperties)] : []
 			],
@@ -263,6 +264,7 @@ module.exports = class SQSHelper {
 	static createEventSource(arn, {
 		batchSize,
 		maximumBatchingWindow,
+		maximumConcurrency, // Default
 		eventProperties
 	}) {
 		return {
@@ -271,6 +273,7 @@ module.exports = class SQSHelper {
 				functionResponseType: 'ReportBatchItemFailures',
 				...batchSize && { batchSize },
 				...maximumBatchingWindow && { maximumBatchingWindow },
+				...!eventProperties?.maximumConcurrency && { maximumConcurrency },
 				...eventProperties
 			}
 		};

--- a/tests/unit/hook-builder/sqs.js
+++ b/tests/unit/hook-builder/sqs.js
@@ -186,7 +186,8 @@ describe('Hook Builder Helpers', () => {
 						arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
 						functionResponseType: 'ReportBatchItemFailures',
 						batchSize: 10,
-						maximumBatchingWindow: 20
+						maximumBatchingWindow: 20,
+						maximumConcurrency: 10
 					}
 				}
 			]
@@ -401,7 +402,8 @@ describe('Hook Builder Helpers', () => {
 								sqs: {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestDLQ',
 									functionResponseType: 'ReportBatchItemFailures',
-									batchSize: 10
+									batchSize: 10,
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -444,6 +446,7 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestBeginQueue',
 									functionResponseType: 'ReportBatchItemFailures',
 									batchSize: 10,
+									maximumConcurrency: 10,
 									maximumBatchingWindow: 20
 								}
 							}
@@ -490,7 +493,8 @@ describe('Hook Builder Helpers', () => {
 								sqs: {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestBeginDLQ',
 									functionResponseType: 'ReportBatchItemFailures',
-									batchSize: 10
+									batchSize: 10,
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -507,7 +511,8 @@ describe('Hook Builder Helpers', () => {
 						arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestDLQ',
 						functionResponseType: 'ReportBatchItemFailures',
 						batchSize: 50,
-						maximumBatchingWindow: 30
+						maximumBatchingWindow: 30,
+						maximumConcurrency: 10
 					}
 				});
 
@@ -574,7 +579,8 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
 									functionResponseType: 'ReportBatchItemFailures',
 									batchSize: 20,
-									maximumBatchingWindow: 80
+									maximumBatchingWindow: 80,
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -612,6 +618,7 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestDLQ',
 									functionResponseType: 'ReportBatchItemFailures',
 									batchSize: 20,
+									maximumConcurrency: 10,
 									maximumBatchingWindow: 80
 								}
 							}
@@ -644,7 +651,8 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
 									functionResponseType: 'ReportBatchItemFailures',
 									batchSize: 10,
-									maximumBatchingWindow: 20
+									maximumBatchingWindow: 20,
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -679,6 +687,7 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
 									batchSize: 10,
 									maximumBatchingWindow: 20,
+									maximumConcurrency: 10,
 									functionResponseType: null
 								}
 							}
@@ -718,7 +727,8 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
 									functionResponseType: 'ReportBatchItemFailures',
 									batchSize: 10,
-									maximumBatchingWindow: 20
+									maximumBatchingWindow: 20,
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -872,7 +882,8 @@ describe('Hook Builder Helpers', () => {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}MyFifoQueue.fifo',
 									functionResponseType: 'ReportBatchItemFailures',
 									batchSize: 10,
-									maximumBatchingWindow: 20
+									maximumBatchingWindow: 20,
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -928,7 +939,8 @@ describe('Hook Builder Helpers', () => {
 							{
 								sqs: {
 									arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}MyFifoDLQ.fifo',
-									functionResponseType: 'ReportBatchItemFailures'
+									functionResponseType: 'ReportBatchItemFailures',
+									maximumConcurrency: 10
 								}
 							}
 						]
@@ -1005,7 +1017,8 @@ describe('Hook Builder Helpers', () => {
 							arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestDelayQueue',
 							functionResponseType: 'ReportBatchItemFailures',
 							batchSize: 10,
-							maximumBatchingWindow: 20
+							maximumBatchingWindow: 20,
+							maximumConcurrency: 10
 						}
 					}]
 				}];
@@ -1043,7 +1056,8 @@ describe('Hook Builder Helpers', () => {
 						arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestDelayQueue',
 						functionResponseType: 'ReportBatchItemFailures',
 						batchSize: 50,
-						maximumBatchingWindow: 30
+						maximumBatchingWindow: 30,
+						maximumConcurrency: 10
 					}
 				});
 


### PR DESCRIPTION
# Descripcion

Actualmente el paquete [npm: sls-helper-plugin-janis](https://www.npmjs.com/package/sls-helper-plugin-janis)  define valores default al crear colas SQS, pero no contempla el valor maximumConcurrency.
Esto implica que, si un proceso necesita escalar y la propiedad no está definida, AWS permitirá una cantidad ilimitada de instancias concurrentes del consumer, lo que puede:

Saturar la base de datos o generar un gasto desmedido.

Consumir el límite de 1000 lambdas en paralelo que AWS permite.

Impactar a todos los servicios de la cuenta.

# Solucion al problema

Definir un valor default de 10 para maximumConcurrency.

Implementar el default en lib/sqs-helper/helper/default.js.

Revisar si es necesario agregar un default adicional para eventProperties, ya que maximumConcurrency se setea en un nivel anidado dentro de consumerProperties.eventProperties.

Mantener compatibilidad con configuraciones personalizadas: si el usuario define manualmente maximumConcurrency, debe respetarse ese valor en lugar del default.