### PR TITLE
fix(sqs): cap eventProperties.batchSize in low env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Low environment SQS batch size cap now also applies when `batchSize` is defined inside `eventProperties`, preventing the invalid `maximumBatchingWindow: 0` + `batchSize > 10` combination that AWS rejects
 
 ## [11.2.1] - 2026-06-05
 ### Added

--- a/lib/sqs-helper/index.js
+++ b/lib/sqs-helper/index.js
@@ -204,6 +204,15 @@ module.exports = class SQSHelper {
 
 			if(consumerProperties.batchSize > 10)
 				consumerProperties.batchSize = 10;
+
+			// batchSize may also live inside eventProperties, which overrides the top-level value when the event
+			// source is built. Cap it too, otherwise window 0 + batchSize > 10 yields a template AWS rejects.
+			if(consumerProperties.eventProperties?.batchSize > 10) {
+				consumerProperties.eventProperties = {
+					...consumerProperties.eventProperties,
+					batchSize: 10
+				};
+			}
 		}
 	}
 

--- a/tests/unit/hook-builder/sqs.js
+++ b/tests/unit/hook-builder/sqs.js
@@ -1757,6 +1757,48 @@ describe('Hook Builder Helpers', () => {
 				});
 			});
 
+			it('Should cap batchSize to 10 when it is defined inside eventProperties and the batching window is overridden', () => {
+
+				process.env.ENV = 'beta';
+
+				const hooks = SQSHelper.buildHooks({
+					name: 'Test',
+					consumerProperties: { eventProperties: { batchSize: 20, maximumConcurrency: 2 } }
+				});
+
+				const [, consumerHook] = hooks;
+				const [, { events }] = consumerHook;
+
+				assert.deepStrictEqual(events[0].sqs, {
+					arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
+					functionResponseType: 'ReportBatchItemFailures',
+					batchSize: 10,
+					maximumBatchingWindow: 0,
+					maximumConcurrency: 2
+				});
+			});
+
+			it('Should keep batchSize from eventProperties when keepBatchingWindow is true', () => {
+
+				process.env.ENV = 'beta';
+
+				const hooks = SQSHelper.buildHooks({
+					name: 'Test',
+					consumerProperties: { keepBatchingWindow: true, maximumBatchingWindow: 5, eventProperties: { batchSize: 20, maximumConcurrency: 2 } }
+				});
+
+				const [, consumerHook] = hooks;
+				const [, { events }] = consumerHook;
+
+				assert.deepStrictEqual(events[0].sqs, {
+					arn: 'arn:aws:sqs:${aws:region}:${aws:accountId}:${self:custom.serviceName}TestQueue',
+					functionResponseType: 'ReportBatchItemFailures',
+					batchSize: 20,
+					maximumBatchingWindow: 5,
+					maximumConcurrency: 2
+				});
+			});
+
 			it('Should keep maximumBatchingWindow when keepBatchingWindow is true in beta env', () => {
 
 				process.env.ENV = 'beta';


### PR DESCRIPTION
## Jira

- Bug: [DEL-3504](https://janiscommerce.atlassian.net/browse/DEL-3504)
- Subtarea: [DEL-3505](https://janiscommerce.atlassian.net/browse/DEL-3505)

## El problema

En low environments (local, beta, qa), `SQSHelper.adjustConsumerForLowEnv` fuerza `maximumBatchingWindow` a `0` y, para no caer en una combinación inválida, capa `batchSize` a `10`. La regla de AWS es:

> *Maximum batch window in seconds must be greater than 0 if maximum batch size is greater than 10*

El cap, sin embargo, solo miraba el `batchSize` **top-level** de `consumerProperties`:

```js
if(consumerProperties.batchSize > 10)
    consumerProperties.batchSize = 10;
```

Pero un consumer también puede definir `batchSize` dentro de `eventProperties`. Y en `createEventSource` el `...eventProperties` se spreadea **último**, por lo que pisa el `batchSize` ya ajustado:

```js
...batchSize && { batchSize },
...Number.isInteger(maximumBatchingWindow) && { maximumBatchingWindow },
...!eventProperties?.maximumConcurrency && { maximumConcurrency },
...eventProperties   // <-- pisa el batchSize topeado
```

Resultado en low env para un consumer con `eventProperties: { batchSize: 20 }`: queda `maximumBatchingWindow: 0` + `batchSize: 20` → AWS rechaza el `EventSourceMapping` y **rompe el deploy** (falla al hacer el UPDATE del recurso en beta/QA).

Este patrón (poner `batchSize` en `eventProperties`) se usa en consumers que necesitan batches grandes con deduplicación por contenido, así que no es un caso de borde.

## La solución

En `adjustConsumerForLowEnv`, cuando se overridea la window, capar también `eventProperties.batchSize` a `10`:

```js
if(consumerProperties.eventProperties?.batchSize > 10) {
    consumerProperties.eventProperties = {
        ...consumerProperties.eventProperties,
        batchSize: 10
    };
}
```

Así la salida en low env es válida sin importar dónde esté definido `batchSize`. `keepBatchingWindow: true` sigue siendo el opt-out explícito de todo el ajuste, igual que antes.

## Tests

- Cap aplicado cuando `batchSize` vive en `eventProperties` y se overridea la window.
- `batchSize` de `eventProperties` preservado cuando `keepBatchingWindow: true`.

lint ✅ · 255 tests ✅ · coverage 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)