### PR TITLE
Resolver el parámetro compartido vía la env var DEVOPS_ACCOUNT_ID en vez de descubrimiento por RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `DEVOPS_ACCOUNT_ID` environment variable is now injected into services by default
+
+### Changed
+- The shared `accountsIdsByService` parameter is now resolved via a constructed ARN using `DEVOPS_ACCOUNT_ID` instead of RAM resource discovery
 
 ## [11.2.1] - 2026-06-05
 ### Added

--- a/lib/utils/default-env-vars.js
+++ b/lib/utils/default-env-vars.js
@@ -3,5 +3,6 @@
 module.exports = {
 	JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
 	JANIS_ENV: '${self:custom.stage}',
-	MS_PATH: 'src'
+	MS_PATH: 'src',
+	DEVOPS_ACCOUNT_ID: '${env:DEVOPS_ACCOUNT_ID}'
 };

--- a/lib/utils/parameter-store.js
+++ b/lib/utils/parameter-store.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const { RAMClient, ListResourcesCommand } = require('@aws-sdk/client-ram');
 const { SSMClient, GetParameterCommand } = require('@aws-sdk/client-ssm');
 const { isLocal } = require('./is-local');
 
 const ssmClient = new SSMClient();
-const ramClient = new RAMClient();
 
 const parametersCache = {};
 
@@ -26,19 +24,22 @@ module.exports.getSharedParameter = async parameterName => {
 	if(parametersCache[parameterName])
 		return parametersCache[parameterName];
 
-	const { resources } = await ramClient.send(new ListResourcesCommand({
-		resourceOwner: 'OTHER-ACCOUNTS',
-		resourceType: 'ssm:Parameter'
-	}));
+	const devopsAccountId = process.env.DEVOPS_ACCOUNT_ID;
 
-	const sharedParameter = resources.find(parameter => parameter.arn.endsWith(`:parameter/${parameterName.replace(/^\//, '')}`));
+	if(!devopsAccountId)
+		throw new Error(`Missing DEVOPS_ACCOUNT_ID env var to resolve shared parameter ${parameterName}`);
 
-	if(!sharedParameter)
-		throw new Error(`Could not find shared parameter ${parameterName}`);
+	const region = process.env.AWS_REGION || 'us-east-1';
 
-	parametersCache[parameterName] = await getParameter(sharedParameter.arn);
+	const arn = `arn:aws:ssm:${region}:${devopsAccountId}:parameter/${parameterName.replace(/^\//, '')}`;
+
+	parametersCache[parameterName] = await getParameter(arn);
 
 	return parametersCache[parameterName];
 };
 
 module.exports.getLocalParameter = getParameter;
+
+module.exports.clearCache = () => {
+	Object.keys(parametersCache).forEach(key => delete parametersCache[key]);
+};

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@aws-sdk/client-ram": "^3.777.0",
     "@aws-sdk/client-ssm": "^3.777.0",
     "fastest-validator": "^1.19.0",
     "lllog": "^1.1.2",

--- a/tests/unit/hooks/base.js
+++ b/tests/unit/hooks/base.js
@@ -47,7 +47,8 @@ describe('Hooks', () => {
 				environment: {
 					JANIS_SERVICE_NAME: '${self:custom.serviceCode}',
 					JANIS_ENV: '${self:custom.stage}',
-					MS_PATH: 'src'
+					MS_PATH: 'src',
+					DEVOPS_ACCOUNT_ID: '${env:DEVOPS_ACCOUNT_ID}'
 				},
 				tags: {
 					Owner: 'Janis',

--- a/tests/unit/utils/parameter-store.js
+++ b/tests/unit/utils/parameter-store.js
@@ -4,33 +4,21 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 const { mockClient } = require('aws-sdk-client-mock');
-const { RAMClient, ListResourcesCommand } = require('@aws-sdk/client-ram');
 const { SSMClient, GetParameterCommand } = require('@aws-sdk/client-ssm');
 
 const ParameterStore = require('../../../lib/utils/parameter-store');
+
+const FAKE_DEVOPS_ACCOUNT_ID = '000000000000';
+const FAKE_REGION = 'us-east-1';
 
 describe('Parameter Store', () => {
 
 	describe('getSharedParameter()', () => {
 
-		let ramMock;
 		let ssmMock;
 
 		beforeEach(() => {
-			ramMock = mockClient(RAMClient);
 			ssmMock = mockClient(SSMClient);
-
-			ramMock.on(ListResourcesCommand).resolves({
-				resources: [{
-					arn: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam',
-					type: 'ssm:Parameter',
-					resourceShareArn: 'arn:aws:ram:us-east-1:000000000000:resource-share/8aa109bd-254c-4c58-86a9-a0e82cad4cb8',
-					status: 'AVAILABLE',
-					creationTime: '2024-10-22T16:59:19.275000-03:00',
-					lastUpdatedTime: '2024-10-22T16:59:21.802000-03:00',
-					resourceRegionScope: 'REGIONAL'
-				}]
-			});
 
 			ssmMock.on(GetParameterCommand).resolves({
 				Parameter: {
@@ -39,13 +27,16 @@ describe('Parameter Store', () => {
 					Value: '{"foo":"bar"}',
 					Version: 1,
 					LastModifiedDate: '2024-10-22T16:57:48.292000-03:00',
-					ARN: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam',
+					ARN: `arn:aws:ssm:${FAKE_REGION}:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeParam`,
 					DataType: 'text'
 				}
 			});
 		});
 
-		afterEach(() => sinon.restore());
+		afterEach(() => {
+			sinon.restore();
+			ParameterStore.clearCache();
+		});
 
 		it('Should resolve an empty object in local env', async () => {
 
@@ -59,140 +50,121 @@ describe('Parameter Store', () => {
 			assert.deepStrictEqual(result, {});
 		});
 
-		it('Should reject if the shared parameter does not exist', async () => {
+		it('Should reject if DEVOPS_ACCOUNT_ID env var is missing', async () => {
 
-			ramMock.on(ListResourcesCommand).resolves({
-				resources: []
+			sinon.stub(process, 'env').value({
+				...process.env,
+				DEVOPS_ACCOUNT_ID: undefined,
+				JANIS_LOCAL: undefined
 			});
 
-			await assert.rejects(() => ParameterStore.getSharedParameter('SomeParam'), {
-				message: 'Could not find shared parameter SomeParam'
-			});
-
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand).length, 1);
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand, {
-				resourceOwner: 'OTHER-ACCOUNTS',
-				resourceType: 'ssm:Parameter'
-			}).length, 1);
+			await assert.rejects(
+				() => ParameterStore.getSharedParameter('SomeParam'),
+				{ message: 'Missing DEVOPS_ACCOUNT_ID env var to resolve shared parameter SomeParam' }
+			);
 
 			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 0);
 		});
 
-		it('Should reject if the SSM parameter does not exist', async () => {
+		it('Should resolve the JSON-parsed parameter value using the constructed ARN', async () => {
 
-			ssmMock.on(GetParameterCommand).rejects(new Error('Parameter does not exist'));
-
-			await assert.rejects(() => ParameterStore.getSharedParameter('SomeParam'));
-
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand).length, 1);
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand, {
-				resourceOwner: 'OTHER-ACCOUNTS',
-				resourceType: 'ssm:Parameter'
-			}).length, 1);
-
-			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 1);
-			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand, {
-				Name: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam'
-			}).length, 1);
-		});
-
-		it('Should resolve the JSON-parsed parameter value if no errors occur', async () => {
-
-			ramMock.on(ListResourcesCommand).resolves({
-				resources: [{
-					arn: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam',
-					type: 'ssm:Parameter',
-					resourceShareArn: 'arn:aws:ram:us-east-1:000000000000:resource-share/8aa109bd-254c-4c58-86a9-a0e82cad4cb8',
-					status: 'AVAILABLE',
-					creationTime: '2024-10-22T16:59:19.275000-03:00',
-					lastUpdatedTime: '2024-10-22T16:59:21.802000-03:00',
-					resourceRegionScope: 'REGIONAL'
-				}]
+			sinon.stub(process, 'env').value({
+				...process.env,
+				DEVOPS_ACCOUNT_ID: FAKE_DEVOPS_ACCOUNT_ID,
+				AWS_REGION: FAKE_REGION,
+				JANIS_LOCAL: undefined
 			});
 
 			const parameterValue = await ParameterStore.getSharedParameter('SomeParam');
 
-			assert.deepStrictEqual(parameterValue, {
-				foo: 'bar'
-			});
-
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand).length, 1);
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand, {
-				resourceOwner: 'OTHER-ACCOUNTS',
-				resourceType: 'ssm:Parameter'
-			}).length, 1);
+			assert.deepStrictEqual(parameterValue, { foo: 'bar' });
 
 			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 1);
 			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand, {
-				Name: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam'
+				Name: `arn:aws:ssm:${FAKE_REGION}:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeParam`
 			}).length, 1);
 		});
 
-		it('Should store the parameter in cache for consecutive calls', async () => {
+		it('Should strip a leading slash from the parameter name when building the ARN', async () => {
 
-			ramMock.on(ListResourcesCommand)
-				.resolvesOnce({
-					resources: [{
-						arn: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam2',
-						type: 'ssm:Parameter',
-						resourceShareArn: 'arn:aws:ram:us-east-1:000000000000:resource-share/8aa109bd-254c-4c58-86a9-a0e82cad4cb8',
-						status: 'AVAILABLE',
-						creationTime: '2024-10-22T16:59:19.275000-03:00',
-						lastUpdatedTime: '2024-10-22T16:59:21.802000-03:00',
-						resourceRegionScope: 'REGIONAL'
-					}]
-				})
-				.resolvesOnce({
-					resources: [{
-						arn: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam3',
-						type: 'ssm:Parameter',
-						resourceShareArn: 'arn:aws:ram:us-east-1:000000000000:resource-share/8aa109bd-254c-4c58-86a9-a0e82cad4cb8',
-						status: 'AVAILABLE',
-						creationTime: '2024-10-22T16:59:19.275000-03:00',
-						lastUpdatedTime: '2024-10-22T16:59:21.802000-03:00',
-						resourceRegionScope: 'REGIONAL'
-					}]
-				});
-			ssmMock.on(GetParameterCommand)
-				.resolves({
-					Parameter: {
-						Name: 'SomeParam2',
-						Type: 'String',
-						Value: '{"foo":"bar"}',
-						Version: 1,
-						LastModifiedDate: '2024-10-22T16:57:48.292000-03:00',
-						ARN: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam2',
-						DataType: 'text'
-					}
-				})
-				.resolves({
-					Parameter: {
-						Name: 'SomeParam3',
-						Type: 'String',
-						Value: '{"foo":"bar"}',
-						Version: 1,
-						LastModifiedDate: '2024-10-22T16:57:48.292000-03:00',
-						ARN: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam3',
-						DataType: 'text'
-					}
-				});
+			sinon.stub(process, 'env').value({
+				...process.env,
+				DEVOPS_ACCOUNT_ID: FAKE_DEVOPS_ACCOUNT_ID,
+				AWS_REGION: FAKE_REGION,
+				JANIS_LOCAL: undefined
+			});
 
-			await ParameterStore.getSharedParameter('SomeParam2');
-			await ParameterStore.getSharedParameter('SomeParam3');
-			await ParameterStore.getSharedParameter('SomeParam3');
+			await ParameterStore.getSharedParameter('/SomeLeadingSlashParam');
 
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand).length, 2);
-			assert.deepStrictEqual(ramMock.commandCalls(ListResourcesCommand, {
-				resourceOwner: 'OTHER-ACCOUNTS',
-				resourceType: 'ssm:Parameter'
-			}).length, 2);
-
-			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 2);
 			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand, {
-				Name: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam2'
+				Name: `arn:aws:ssm:${FAKE_REGION}:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeLeadingSlashParam`
 			}).length, 1);
+		});
+
+		it('Should use us-east-1 as default region when AWS_REGION is not set', async () => {
+
+			sinon.stub(process, 'env').value({
+				...process.env,
+				DEVOPS_ACCOUNT_ID: FAKE_DEVOPS_ACCOUNT_ID,
+				AWS_REGION: undefined,
+				JANIS_LOCAL: undefined
+			});
+
+			await ParameterStore.getSharedParameter('SomeParamDefaultRegion');
+
+			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 1);
 			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand, {
-				Name: 'arn:aws:ssm:us-east-1:000000000000:parameter/SomeParam3'
+				Name: `arn:aws:ssm:us-east-1:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeParamDefaultRegion`
+			}).length, 1);
+		});
+
+		it('Should store the parameter in cache and not call SSM on consecutive calls', async () => {
+
+			sinon.stub(process, 'env').value({
+				...process.env,
+				DEVOPS_ACCOUNT_ID: FAKE_DEVOPS_ACCOUNT_ID,
+				AWS_REGION: FAKE_REGION,
+				JANIS_LOCAL: undefined
+			});
+
+			ssmMock.on(GetParameterCommand).resolves({
+				Parameter: {
+					Name: 'SomeParam4',
+					Type: 'String',
+					Value: '{"foo":"bar"}',
+					Version: 1,
+					LastModifiedDate: '2024-10-22T16:57:48.292000-03:00',
+					ARN: `arn:aws:ssm:${FAKE_REGION}:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeParam4`,
+					DataType: 'text'
+				}
+			});
+
+			await ParameterStore.getSharedParameter('SomeParam4');
+			await ParameterStore.getSharedParameter('SomeParam4');
+			await ParameterStore.getSharedParameter('SomeParam4');
+
+			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 1);
+			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand, {
+				Name: `arn:aws:ssm:${FAKE_REGION}:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeParam4`
+			}).length, 1);
+		});
+
+		it('Should reject if the SSM GetParameter call fails', async () => {
+
+			sinon.stub(process, 'env').value({
+				...process.env,
+				DEVOPS_ACCOUNT_ID: FAKE_DEVOPS_ACCOUNT_ID,
+				AWS_REGION: FAKE_REGION,
+				JANIS_LOCAL: undefined
+			});
+
+			ssmMock.on(GetParameterCommand).rejects(new Error('Parameter does not exist'));
+
+			await assert.rejects(() => ParameterStore.getSharedParameter('SomeParamFailing'));
+
+			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand).length, 1);
+			assert.deepStrictEqual(ssmMock.commandCalls(GetParameterCommand, {
+				Name: `arn:aws:ssm:${FAKE_REGION}:${FAKE_DEVOPS_ACCOUNT_ID}:parameter/SomeParamFailing`
 			}).length, 1);
 		});
 


### PR DESCRIPTION
## Qué

El parámetro compartido `accountsIdsByService` (usado para armar los ARNs cross-account de los topics SNS) se resolvía descubriendo su ARN vía RAM `ListResources(OTHER-ACCOUNTS)`. Esta PR reemplaza ese descubrimiento por un ARN construido a partir de una nueva variable de entorno `DEVOPS_ACCOUNT_ID` + la región, resuelto con una única llamada `GetParameter`.

## Cambios

- **Agregado** `DEVOPS_ACCOUNT_ID` a las env vars por default de los services (`default-env-vars.js`).
- **Cambiado** `getSharedParameter` para construir `arn:aws:ssm:{region}:{DEVOPS_ACCOUNT_ID}:parameter/{name}` y llamar `GetParameter` directo. Se preservan `isLocal() → {}` y la cache en memoria; se normaliza el slash inicial en el nombre del parámetro; lanza un error claro si falta `DEVOPS_ACCOUNT_ID`.
- **Eliminada** la dependencia `@aws-sdk/client-ram`, ahora sin uso.
- Tests actualizados (sin mock de RAM); lint + 255 specs en verde.

## A tener en cuenta

Esto hace que el plugin **requiera `DEVOPS_ACCOUNT_ID` disponible en deploy-time** para resolver el parámetro compartido (antes se descubría vía RAM sin env var). En el pipeline de Janis ese valor se provee a través de `/shared/{env}/ci-cd`.
